### PR TITLE
fix: resolve all failing tests and expand abbreviated hex output

### DIFF
--- a/src/app/_candor/form/checkbox/checkbox.component.spec.ts
+++ b/src/app/_candor/form/checkbox/checkbox.component.spec.ts
@@ -28,7 +28,7 @@ describe('CheckboxComponent', () => {
   });
 
   it('should reflect the checked input', () => {
-    component.checked = true;
+    fixture.componentRef.setInput('checked', true);
     fixture.detectChanges();
     const input = fixture.nativeElement.querySelector('input[type=checkbox]');
     expect(input.checked).toBeTrue();

--- a/src/app/_components/tone-picker/tone-picker.component.spec.ts
+++ b/src/app/_components/tone-picker/tone-picker.component.spec.ts
@@ -142,7 +142,7 @@ describe('TonePickerComponent', () => {
   describe('setsize computed', () => {
     it('should count only non-disabled cells', () => {
       // ROWS has 3 non-disabled cells (row0col0, row1col0, row1col1)
-      expect(component.setsize()).toBe(3);
+      expect((component as any).setsize()).toBe(3);
     });
   });
 

--- a/src/app/services/color-util.service.ts
+++ b/src/app/services/color-util.service.ts
@@ -50,7 +50,9 @@ export class ColorUtilService {
   toHexString(color: string): string | null {
     const parsed = this.parseColor(color);
     if (!parsed) return null;
-    return new Color(parsed).to('srgb').toString({ format: 'hex' });
+    const hex = new Color(parsed).to('srgb').toString({ format: 'hex' });
+    // colorjs.io may return 3-digit shorthand (#fff) — expand to 6-digit for okca compatibility
+    return hex.replace(/^#([0-9a-f])([0-9a-f])([0-9a-f])$/i, '#$1$1$2$2$3$3');
   }
 
   hexToOklchString(color: string): string {


### PR DESCRIPTION
## Summary

- Fixed `CheckboxComponent` spec using `fixture.componentRef.setInput()` instead of direct property assignment, which doesn't trigger change detection in zoneless mode
- Fixed `TonePickerComponent` spec accessing `protected` member `setsize()` via `(component as any)` cast
- Fixed `toHexString()` in `ColorUtilService` to expand 3-digit hex shorthand (`#fff`) from colorjs.io to 6-digit (`#ffffff`) for compatibility with `@pawn002/okca`

## Test plan

- [ ] Run `npm test` — all 436 tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)