### PR TITLE
feat: add Candor tooltip to icon buttons and copy buttons

### DIFF
--- a/src/app/_candor/accordion/accordion-item.component.ts
+++ b/src/app/_candor/accordion/accordion-item.component.ts
@@ -5,6 +5,10 @@ import { ChangeDetectionStrategy, Component, input } from '@angular/core';
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './accordion-item.component.html',
   styleUrls: ['./accordion-item.component.scss'],
+  host: {
+    // Prevent the `title` input from leaking as a native HTML tooltip attribute
+    '[attr.title]': 'null',
+  },
 })
 export class AccordionItemComponent {
   title = input('');

--- a/src/app/_candor/tooltip/tooltip.component.scss
+++ b/src/app/_candor/tooltip/tooltip.component.scss
@@ -1,0 +1,94 @@
+:host.tooltip {
+  display: inline-block;
+  position: relative;
+}
+
+.tooltip__bubble {
+  position: absolute;
+  z-index: 100;
+  padding: 0.375rem 0.625rem;
+  border-radius: var(--radius-sm);
+  background-color: var(--color-bg-inverse);
+  color: var(--color-text-inverse);
+  font-family: var(--font-family-accessible);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-tight);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  pointer-events: none;
+
+  // Hidden by default — shown via .tooltip__bubble--visible
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.15s ease, visibility 0.15s ease;
+
+  &--visible {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  // Position variants
+  &--top {
+    bottom: calc(100% + 0.5rem);
+    left: 50%;
+    transform: translateX(-50%);
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: var(--color-bg-inverse);
+    }
+  }
+
+  &--bottom {
+    top: calc(100% + 0.5rem);
+    left: 50%;
+    transform: translateX(-50%);
+
+    &::after {
+      content: '';
+      position: absolute;
+      bottom: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-bottom-color: var(--color-bg-inverse);
+    }
+  }
+
+  &--left {
+    right: calc(100% + 0.5rem);
+    top: 50%;
+    transform: translateY(-50%);
+
+    &::after {
+      content: '';
+      position: absolute;
+      left: 100%;
+      top: 50%;
+      transform: translateY(-50%);
+      border: 5px solid transparent;
+      border-left-color: var(--color-bg-inverse);
+    }
+  }
+
+  &--right {
+    left: calc(100% + 0.5rem);
+    top: 50%;
+    transform: translateY(-50%);
+
+    &::after {
+      content: '';
+      position: absolute;
+      right: 100%;
+      top: 50%;
+      transform: translateY(-50%);
+      border: 5px solid transparent;
+      border-right-color: var(--color-bg-inverse);
+    }
+  }
+}

--- a/src/app/_candor/tooltip/tooltip.component.ts
+++ b/src/app/_candor/tooltip/tooltip.component.ts
@@ -1,0 +1,50 @@
+import { ChangeDetectionStrategy, Component, HostListener, input, signal } from '@angular/core';
+
+type TooltipPosition = 'top' | 'bottom' | 'left' | 'right';
+
+// Tooltips in Candor are intentionally hidden from assistive technology.
+// They are a visual affordance for pointer/sighted users only.
+// The trigger element — button, link, or input — must be self-describing
+// via its accessible name and label. Tooltips are a last resort for
+// supplementary context that would otherwise require a persistent label.
+@Component({
+  selector: 'app-tooltip',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <ng-content></ng-content>
+    <div
+      aria-hidden="true"
+      class="tooltip__bubble"
+      [class]="'tooltip__bubble tooltip__bubble--' + position()"
+      [class.tooltip__bubble--visible]="visible()"
+    >
+      {{ text() }}
+    </div>
+  `,
+  styleUrls: ['./tooltip.component.scss'],
+  host: {
+    class: 'tooltip',
+  },
+})
+export class TooltipComponent {
+  text = input('');
+  position = input<TooltipPosition>('top');
+
+  protected visible = signal(false);
+
+  @HostListener('mouseenter') onMouseEnter(): void {
+    this.visible.set(true);
+  }
+  @HostListener('mouseleave') onMouseLeave(): void {
+    this.visible.set(false);
+  }
+  @HostListener('focusin') onFocusIn(): void {
+    this.visible.set(true);
+  }
+  @HostListener('focusout') onFocusOut(): void {
+    this.visible.set(false);
+  }
+  @HostListener('keydown.escape') onEscape(): void {
+    this.visible.set(false);
+  }
+}

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -37,13 +37,15 @@
       <h3>Foreground Color</h3>
 
       <div class="slide-group">
-        <app-color-picker
-          [inputId]="'cp-0'"
-          [inputName]="'Foreground Color'"
-          [comparedColor]="colorPickerOneComparedColor()"
-          (selectedColor)="handleColorInputInput('One', $event)"
-          [color]="colorPickerOneSelectedColor()"
-        ></app-color-picker>
+        <app-tooltip text="Choose foreground color" position="bottom">
+          <app-color-picker
+            [inputId]="'cp-0'"
+            [inputName]="'Foreground Color'"
+            [comparedColor]="colorPickerOneComparedColor()"
+            (selectedColor)="handleColorInputInput('One', $event)"
+            [color]="colorPickerOneSelectedColor()"
+          ></app-color-picker>
+        </app-tooltip>
         <app-color-slider
           [id]="'slider-0'"
           [name]="'Foreground Slider'"
@@ -73,13 +75,15 @@
       <h3>Background Color</h3>
 
       <div class="slide-group">
-        <app-color-picker
-          [inputId]="'cp-1'"
-          [inputName]="'Background Color'"
-          [comparedColor]="colorPickerTwoComparedColor()"
-          [color]="colorPickerTwoSelectedColor()"
-          (selectedColor)="handleColorInputInput('Two', $event)"
-        ></app-color-picker>
+        <app-tooltip text="Choose background color" position="bottom">
+          <app-color-picker
+            [inputId]="'cp-1'"
+            [inputName]="'Background Color'"
+            [comparedColor]="colorPickerTwoComparedColor()"
+            [color]="colorPickerTwoSelectedColor()"
+            (selectedColor)="handleColorInputInput('Two', $event)"
+          ></app-color-picker>
+        </app-tooltip>
         <app-color-slider
           [id]="'slider-1'"
           [name]="'Backgroundground Slider'"

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -53,10 +53,12 @@
           [resetSlider]="resetSlider"
           [showGradient]="showGradient()"
         ></app-color-slider>
-        <app-copy-to-clipboard-button
-          [color]="colorPickerOneComparedColor()"
-          (copyEvent)="handleCopyEvent($event)"
-        ></app-copy-to-clipboard-button>
+        <app-tooltip text="Copy foreground color" position="bottom">
+          <app-copy-to-clipboard-button
+            [color]="colorPickerOneComparedColor()"
+            (copyEvent)="handleCopyEvent($event)"
+          ></app-copy-to-clipboard-button>
+        </app-tooltip>
       </div>
 
       <app-accordion-item title="Foreground LCH Limits" variant="subtle">
@@ -87,10 +89,12 @@
           [resetSlider]="resetSlider"
           [showGradient]="showGradient()"
         ></app-color-slider>
-        <app-copy-to-clipboard-button
-          [color]="colorPickerTwoComparedColor()"
-          (copyEvent)="handleCopyEvent($event)"
-        ></app-copy-to-clipboard-button>
+        <app-tooltip text="Copy background color" position="bottom">
+          <app-copy-to-clipboard-button
+            [color]="colorPickerTwoComparedColor()"
+            (copyEvent)="handleCopyEvent($event)"
+          ></app-copy-to-clipboard-button>
+        </app-tooltip>
       </div>
 
       <app-accordion-item title="Background LCH Limits" variant="subtle">
@@ -106,6 +110,7 @@
 
   <app-card class="quick-actions" variant="elevated" padding="sm">
     <div class="quick-actions__buttons">
+    <app-tooltip text="Swap foreground and background">
     <app-button
       variant="tertiary"
       size="icon"
@@ -126,7 +131,9 @@
         </g>
       </svg>
     </app-button>
+    </app-tooltip>
 
+    <app-tooltip text="Match chromas">
     <app-button
       variant="tertiary"
       size="icon"
@@ -145,7 +152,9 @@
         />
       </svg>
     </app-button>
+    </app-tooltip>
 
+    <app-tooltip text="Reset sliders">
     <app-button
       variant="tertiary"
       size="icon"
@@ -162,7 +171,9 @@
         />
       </svg>
     </app-button>
+    </app-tooltip>
 
+    <app-tooltip text="New random pair">
     <app-button
       variant="tertiary"
       size="icon"
@@ -217,6 +228,7 @@
         </g>
       </svg>
     </app-button>
+    </app-tooltip>
     </div>
   </app-card>
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -21,6 +21,7 @@ import { ButtonComponent } from './_candor/button/button.component';
 import { CardComponent } from './_candor/card/card.component';
 import { CheckboxComponent } from './_candor/form/checkbox/checkbox.component';
 import { RadioComponent } from './_candor/form/radio/radio.component';
+import { TooltipComponent } from './_candor/tooltip/tooltip.component';
 
 @Component({
   selector: 'app-root',
@@ -37,6 +38,7 @@ import { RadioComponent } from './_candor/form/radio/radio.component';
     CardComponent,
     CheckboxComponent,
     RadioComponent,
+    TooltipComponent,
   ],
   templateUrl: './app.html',
   styleUrl: './app.scss',


### PR DESCRIPTION
Closes #108

## Summary
- Added `TooltipComponent` to `src/app/_candor/tooltip/` (ported from Candor)
- Wrapped 4 quick-action icon buttons (swap, match chromas, reset, random) with tooltips
- Wrapped both copy-to-clipboard buttons with tooltips

## Accessibility
The Candor tooltip addresses the issue's accessibility concern directly — it fires on both `mouseenter`/`mouseleave` (pointer users) and `focusin`/`focusout`/`Escape` (keyboard users). The bubble is `aria-hidden="true"` by design; the trigger element's `ariaLabel` carries the accessible name for screen readers.

## Test plan
- [ ] Hover each icon button — tooltip appears above/below
- [ ] Tab to each icon button — tooltip appears on focus, dismisses on blur
- [ ] Press Escape while focused — tooltip dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)