### PR TITLE
deps: upgrade @pawn002/okca to 2.0.2

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,16 +1,15 @@
-import type { StorybookConfig } from '@storybook/angular';
+import type { StorybookConfig } from '@storybook/web-components-vite';
 
 const config: StorybookConfig = {
   stories: [
     '../src/app/**/*.mdx',
     '../src/app/**/*.stories.@(js|jsx|mjs|ts|tsx)',
-    // "../src/**/*.mdx",
-    // "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"
   ],
   addons: ['@storybook/addon-docs'],
   framework: {
-    name: '@storybook/angular',
+    name: '@storybook/web-components-vite',
     options: {},
   },
 };
+
 export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,8 +1,5 @@
-import type { Preview } from '@storybook/angular';
-import { setCompodocJson } from '@storybook/addon-docs/angular';
-import docJson from '../documentation.json';
-
-setCompodocJson(docJson);
+import type { Preview } from '@storybook/web-components';
+import '../src/main';
 
 const preview: Preview = {
   parameters: {

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An Angular 20 application for exploring and iterating on accessible color pairs.
 
 ## Features
 
-- **OKCA Contrast**: Primary contrast algorithm — OKLCH-native, 1–21 scale, zero false passes against WCAG 2.x, stricter for saturated chromatic colors
+- **OKCA Contrast**: Primary contrast algorithm — OKLCH-native, 1–21 scale (20.9 ceiling), zero false passes against WCAG 2.x, stricter for saturated chromatic colors
 - **APCA Support**: Accessible Perceptual Contrast Algorithm for perceptual contrast scoring
 - **WCAG Compatibility**: Bridge-PCA provides WCAG 2.x ratio equivalents
 - **Color Space**: Works in OKLCH color space for perceptually uniform adjustments
@@ -77,9 +77,9 @@ All color manipulation uses OKLCH (Oklab Lightness Chroma Hue) for perceptually 
 
 OKCA (OK Contrast Algorithm) is the default contrast mode. It outputs ratios on the familiar 1–21 scale with the same AA (4.5) and AAA (7.0) thresholds as WCAG, while correcting a known WCAG failure mode:
 
-**Saturated chromatic false passes** — hot pink on near-black can score 6.6:1 under WCAG but is demonstrably harder to read. OKCA applies a chroma penalty that reduces the ratio for vivid colors. It is also polarity-aware: light-on-dark and dark-on-light pairs score differently, capped at 21 and 20 respectively.
+**Saturated chromatic false passes** — hot pink on near-black can score 6.6:1 under WCAG but is demonstrably harder to read. OKCA applies a chroma penalty that reduces the ratio for vivid colors (that pair scores 3.6). It is also polarity-aware: light-on-dark and dark-on-light pairs score differently, capped at 20.9 and 20 respectively. The light-on-dark ceiling sits just below WCAG's 21 so that every OKCA score is *strictly* under the WCAG equivalent.
 
-OKCA never approves a pair that WCAG rejects (FP = 0 by construction), making it a strictly stricter, drop-in alternative.
+OKCA never approves a pair that WCAG rejects (FP = 0, proven for sRGB), making it a strictly stricter, drop-in alternative.
 
 ### APCA, Bridge-PCA, and Delta E
 
@@ -149,6 +149,7 @@ See [LICENSE](./LICENSE) for full details.
 - **2026-04**: Added ModalComponent (`app-modal`) to Candor; replaced accordion anchor links with contextual info buttons and modals throughout the app
 - **2026-04**: Upgraded `@pawn002/okca` to 1.0.1 (ESM, polarity-aware caps); OKCA is now the default contrast type
 - **2026-04**: Fixed checkbox double-toggle bug; fixed tooltip mobile overflow via `@media (hover: none)`
+- **2026-08**: Upgraded `@pawn002/okca` to 2.0.2. v2.0.0 recalibrated the algorithm — mid-tone neutrals and brand chromatics score roughly +0.4–0.5 higher, the white/`#767676` anchor moved 3.5 → 3.9, and the light-on-dark cap dropped from 21 to 20.9 so every score sits strictly below WCAG. Saturated-colour catches are unchanged; AA (4.5) and AAA (7.0) thresholds are unchanged
 
 ---
 

--- a/documentation/services.md
+++ b/documentation/services.md
@@ -387,7 +387,7 @@ Main method to get contrast score between two colors. The app defaults to `'okca
 
 | Type | Scale | Notes |
 |------|-------|-------|
-| `okca` | 1–21 | OKLCH-native, zero WCAG false passes, default |
+| `okca` | 1–21 (20.9 ceiling) | OKLCH-native, polarity-aware, zero WCAG false passes, default |
 | `apca` | ~0–108 | Perceptual contrast, signed (polarity matters) |
 | `bpca` | 1–21 | WCAG 2.x ratio via Bridge-PCA |
 | `deltaE` | 0–100 | CIE Delta E 2000 perceptual color difference |
@@ -395,7 +395,7 @@ Main method to get contrast score between two colors. The app defaults to `'okca
 **Example**:
 ```typescript
 const okca = colorMetricsService.getContrast('#ff69b4', '#1a1a1a', 'okca');
-// Returns: 4.0 (WCAG gives 6.6 — a known false pass)
+// Returns: 3.6 (WCAG gives 6.6 — a known false pass)
 
 const apca = colorMetricsService.getContrast('#000000', '#ffffff', 'apca');
 // Returns: 106 (very high contrast)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Color Pair Quick Iterator</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  </head>
+  <body>
+    <cc-app></cc-app>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,6 @@
       "name": "color-pair-quick-iterator",
       "version": "1.0.0",
       "dependencies": {
-        "@angular/common": "^20.3.0",
-        "@angular/compiler": "^20.3.0",
-        "@angular/core": "^20.3.0",
-        "@angular/forms": "^20.3.0",
-        "@angular/platform-browser": "^20.3.0",
-        "@angular/platform-browser-dynamic": "^20.3.19",
-        "@angular/router": "^20.3.0",
         "@candor-design/tokens": "^1.0.1",
         "@fontsource-variable/roboto-flex": "^5.2.8",
         "@fontsource-variable/roboto-mono": "^5.2.8",
@@ -25,253 +18,20 @@
         "bridge-pca": "^0.1.6",
         "colorjs.io": "^0.5.2",
         "d3": "^7.9.0",
-        "lodash-es": "^4.17.21",
-        "rxjs": "~7.8.0",
-        "tslib": "^2.3.0",
-        "zone.js": "^0.15.1"
+        "lit": "^3.2.0",
+        "lodash-es": "^4.17.21"
       },
       "devDependencies": {
-        "@angular-devkit/build-angular": "^20.3.0",
-        "@angular/build": "^20.3.4",
-        "@angular/cli": "^20.3.4",
-        "@angular/compiler-cli": "^20.3.0",
-        "@compodoc/compodoc": "^1.1.31",
-        "@storybook/addon-docs": "^9.1.10",
-        "@storybook/angular": "^9.1.10",
+        "@storybook/addon-docs": "^8.6.12",
+        "@storybook/web-components": "^8.6.12",
+        "@storybook/web-components-vite": "^8.6.12",
         "@types/d3": "^7.4.3",
-        "@types/jasmine": "~5.1.0",
         "@types/lodash-es": "^4.17.12",
-        "jasmine-core": "~5.9.0",
-        "karma": "~6.4.0",
-        "karma-chrome-launcher": "~3.2.0",
-        "karma-coverage": "~2.2.0",
-        "karma-jasmine": "~5.1.0",
-        "karma-jasmine-html-reporter": "~2.1.0",
-        "storybook": "^9.1.10",
-        "typescript": "~5.9.2"
-      }
-    },
-    "node_modules/@adobe/css-tools": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
-      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@aduh95/viz.js": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@aduh95/viz.js/-/viz.js-3.4.0.tgz",
-      "integrity": "sha512-KI2nVf9JdwWCXqK6RVf+9/096G7VWN4Z84mnynlyZKao2xQENW8WNEjLmvdlxS5X8PNWXFC1zqwm7tveOXw/4A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@algolia/abtesting": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.1.0.tgz",
-      "integrity": "sha512-sEyWjw28a/9iluA37KLGu8vjxEIlb60uxznfTUmXImy7H5NvbpSO6yYgmgH5KiD7j+zTUUihiST0jEP12IoXow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-abtesting": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.35.0.tgz",
-      "integrity": "sha512-uUdHxbfHdoppDVflCHMxRlj49/IllPwwQ2cQ8DLC4LXr3kY96AHBpW0dMyi6ygkn2MtFCc6BxXCzr668ZRhLBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-analytics": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.35.0.tgz",
-      "integrity": "sha512-SunAgwa9CamLcRCPnPHx1V2uxdQwJGqb1crYrRWktWUdld0+B2KyakNEeVn5lln4VyeNtW17Ia7V7qBWyM/Skw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-common": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.35.0.tgz",
-      "integrity": "sha512-ipE0IuvHu/bg7TjT2s+187kz/E3h5ssfTtjpg1LbWMgxlgiaZIgTTbyynM7NfpSJSKsgQvCQxWjGUO51WSCu7w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-insights": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.35.0.tgz",
-      "integrity": "sha512-UNbCXcBpqtzUucxExwTSfAe8gknAJ485NfPN6o1ziHm6nnxx97piIbcBQ3edw823Tej2Wxu1C0xBY06KgeZ7gA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-personalization": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.35.0.tgz",
-      "integrity": "sha512-/KWjttZ6UCStt4QnWoDAJ12cKlQ+fkpMtyPmBgSS2WThJQdSV/4UWcqCUqGH7YLbwlj3JjNirCu3Y7uRTClxvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.35.0.tgz",
-      "integrity": "sha512-8oCuJCFf/71IYyvQQC+iu4kgViTODbXDk3m7yMctEncRSRV+u2RtDVlpGGfPlJQOrAY7OONwJlSHkmbbm2Kp/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-search": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.35.0.tgz",
-      "integrity": "sha512-FfmdHTrXhIduWyyuko1YTcGLuicVbhUyRjO3HbXE4aP655yKZgdTIfMhZ/V5VY9bHuxv/fGEh3Od1Lvv2ODNTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/ingestion": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.35.0.tgz",
-      "integrity": "sha512-gPzACem9IL1Co8mM1LKMhzn1aSJmp+Vp434An4C0OBY4uEJRcqsLN3uLBlY+bYvFg8C8ImwM9YRiKczJXRk0XA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/monitoring": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.35.0.tgz",
-      "integrity": "sha512-w9MGFLB6ashI8BGcQoVt7iLgDIJNCn4OIu0Q0giE3M2ItNrssvb8C0xuwJQyTy1OFZnemG0EB1OvXhIHOvQwWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/recommend": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.35.0.tgz",
-      "integrity": "sha512-AhrVgaaXAb8Ue0u2nuRWwugt0dL5UmRgS9LXe0Hhz493a8KFeZVUE56RGIV3hAa6tHzmAV7eIoqcWTQvxzlJeQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.35.0.tgz",
-      "integrity": "sha512-diY415KLJZ6x1Kbwl9u96Jsz0OstE3asjXtJ9pmk1d+5gPuQ5jQyEsgC+WmEXzlec3iuVszm8AzNYYaqw6B+Zw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.35.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/requester-fetch": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.35.0.tgz",
-      "integrity": "sha512-uydqnSmpAjrgo8bqhE9N1wgcB98psTRRQXcjc4izwMB7yRl9C8uuAQ/5YqRj04U0mMQ+fdu2fcNF6m9+Z1BzDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.35.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/requester-node-http": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.35.0.tgz",
-      "integrity": "sha512-RgLX78ojYOrThJHrIiPzT4HW3yfQa0D7K+MQ81rhxqaNyNBu4F1r+72LNHYH/Z+y9I1Mrjrd/c/Ue5zfDgAEjQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.35.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
+        "sass": "^1.89.0",
+        "storybook": "^8.6.12",
+        "typescript": "~5.7.3",
+        "vite": "^6.3.5",
+        "vitest": "^3.2.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -285,680 +45,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@angular-devkit/architect": {
-      "version": "0.2003.21",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2003.21.tgz",
-      "integrity": "sha512-cdtiGFRW5Sgd8QkEAGw5daYT3Eh0hQtXFkUtnkU1HASpKrLdNLdfEUWho1y6A9bNlXL7fNVCvHOnK+G6Fd++rw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/core": "20.3.21",
-        "rxjs": "7.8.2"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular-devkit/architect/node_modules/@angular-devkit/core": {
-      "version": "20.3.21",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.21.tgz",
-      "integrity": "sha512-+flPAkPPn6MLVOa4ereSo6M5QRqxElKvDL6rCJWOJHRzH7K4CcfA269vr5mQSlImI5ZZc/EAPpm9rwEfWZRwew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "8.18.0",
-        "ajv-formats": "3.0.1",
-        "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.3",
-        "rxjs": "7.8.2",
-        "source-map": "0.7.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "chokidar": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "chokidar": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@angular-devkit/architect/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@angular-devkit/build-angular": {
-      "version": "20.3.21",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-20.3.21.tgz",
-      "integrity": "sha512-RcXDeeUntlu1bajDS/GyZOrC0ROcV57SihseJ+W5FILUOFk0tOmAf2n7JMizLN9s5BKkKbHAtIjp9Y9i+rGemg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2003.21",
-        "@angular-devkit/build-webpack": "0.2003.21",
-        "@angular-devkit/core": "20.3.21",
-        "@angular/build": "20.3.21",
-        "@babel/core": "7.28.3",
-        "@babel/generator": "7.28.3",
-        "@babel/helper-annotate-as-pure": "7.27.3",
-        "@babel/helper-split-export-declaration": "7.24.7",
-        "@babel/plugin-transform-async-generator-functions": "7.28.0",
-        "@babel/plugin-transform-async-to-generator": "7.27.1",
-        "@babel/plugin-transform-runtime": "7.28.3",
-        "@babel/preset-env": "7.28.3",
-        "@babel/runtime": "7.28.3",
-        "@discoveryjs/json-ext": "0.6.3",
-        "@ngtools/webpack": "20.3.21",
-        "ansi-colors": "4.1.3",
-        "autoprefixer": "10.4.21",
-        "babel-loader": "10.0.0",
-        "browserslist": "^4.21.5",
-        "copy-webpack-plugin": "14.0.0",
-        "css-loader": "7.1.2",
-        "esbuild-wasm": "0.25.9",
-        "fast-glob": "3.3.3",
-        "http-proxy-middleware": "3.0.5",
-        "istanbul-lib-instrument": "6.0.3",
-        "jsonc-parser": "3.3.1",
-        "karma-source-map-support": "1.4.0",
-        "less": "4.4.0",
-        "less-loader": "12.3.0",
-        "license-webpack-plugin": "4.0.2",
-        "loader-utils": "3.3.1",
-        "mini-css-extract-plugin": "2.9.4",
-        "open": "10.2.0",
-        "ora": "8.2.0",
-        "picomatch": "4.0.3",
-        "piscina": "5.1.3",
-        "postcss": "8.5.6",
-        "postcss-loader": "8.1.1",
-        "resolve-url-loader": "5.0.0",
-        "rxjs": "7.8.2",
-        "sass": "1.90.0",
-        "sass-loader": "16.0.5",
-        "semver": "7.7.2",
-        "source-map-loader": "5.0.0",
-        "source-map-support": "0.5.21",
-        "terser": "5.43.1",
-        "tree-kill": "1.2.2",
-        "tslib": "2.8.1",
-        "webpack": "5.105.0",
-        "webpack-dev-middleware": "7.4.2",
-        "webpack-dev-server": "5.2.2",
-        "webpack-merge": "6.0.1",
-        "webpack-subresource-integrity": "5.1.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "optionalDependencies": {
-        "esbuild": "0.25.9"
-      },
-      "peerDependencies": {
-        "@angular/compiler-cli": "^20.0.0",
-        "@angular/core": "^20.0.0",
-        "@angular/localize": "^20.0.0",
-        "@angular/platform-browser": "^20.0.0",
-        "@angular/platform-server": "^20.0.0",
-        "@angular/service-worker": "^20.0.0",
-        "@angular/ssr": "^20.3.21",
-        "@web/test-runner": "^0.20.0",
-        "browser-sync": "^3.0.2",
-        "jest": "^29.5.0 || ^30.2.0",
-        "jest-environment-jsdom": "^29.5.0 || ^30.2.0",
-        "karma": "^6.3.0",
-        "ng-packagr": "^20.0.0",
-        "protractor": "^7.0.0",
-        "tailwindcss": "^2.0.0 || ^3.0.0 || ^4.0.0",
-        "typescript": ">=5.8 <6.0"
-      },
-      "peerDependenciesMeta": {
-        "@angular/core": {
-          "optional": true
-        },
-        "@angular/localize": {
-          "optional": true
-        },
-        "@angular/platform-browser": {
-          "optional": true
-        },
-        "@angular/platform-server": {
-          "optional": true
-        },
-        "@angular/service-worker": {
-          "optional": true
-        },
-        "@angular/ssr": {
-          "optional": true
-        },
-        "@web/test-runner": {
-          "optional": true
-        },
-        "browser-sync": {
-          "optional": true
-        },
-        "jest": {
-          "optional": true
-        },
-        "jest-environment-jsdom": {
-          "optional": true
-        },
-        "karma": {
-          "optional": true
-        },
-        "ng-packagr": {
-          "optional": true
-        },
-        "protractor": {
-          "optional": true
-        },
-        "tailwindcss": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@angular-devkit/build-angular/node_modules/@angular-devkit/core": {
-      "version": "20.3.21",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.21.tgz",
-      "integrity": "sha512-+flPAkPPn6MLVOa4ereSo6M5QRqxElKvDL6rCJWOJHRzH7K4CcfA269vr5mQSlImI5ZZc/EAPpm9rwEfWZRwew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "8.18.0",
-        "ajv-formats": "3.0.1",
-        "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.3",
-        "rxjs": "7.8.2",
-        "source-map": "0.7.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "chokidar": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "chokidar": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@angular-devkit/build-angular/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.2003.21",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2003.21.tgz",
-      "integrity": "sha512-yWYhRA6mcGYYcGm1bmmqFiYabFSt6RA5pStduHr9my/uTBWaPyda/HwnleF5p/QN8pgN3BLCjrDS1njiGu8ORg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/architect": "0.2003.21",
-        "rxjs": "7.8.2"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.30.0",
-        "webpack-dev-server": "^5.0.2"
-      }
-    },
-    "node_modules/@angular-devkit/schematics": {
-      "version": "20.3.21",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.21.tgz",
-      "integrity": "sha512-CFX8TrZvvm4G398DpbcJ2GY8kwR81M8ssyIVYn19gD4Kr2UmeiCT3/dtUpx2FvSvSHbNwLmU6Ym0Rkh+E7p9bQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/core": "20.3.21",
-        "jsonc-parser": "3.3.1",
-        "magic-string": "0.30.17",
-        "ora": "8.2.0",
-        "rxjs": "7.8.2"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular-devkit/schematics/node_modules/@angular-devkit/core": {
-      "version": "20.3.21",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.21.tgz",
-      "integrity": "sha512-+flPAkPPn6MLVOa4ereSo6M5QRqxElKvDL6rCJWOJHRzH7K4CcfA269vr5mQSlImI5ZZc/EAPpm9rwEfWZRwew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "8.18.0",
-        "ajv-formats": "3.0.1",
-        "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.3",
-        "rxjs": "7.8.2",
-        "source-map": "0.7.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "chokidar": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "chokidar": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@angular-devkit/schematics/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@angular/build": {
-      "version": "20.3.21",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-20.3.21.tgz",
-      "integrity": "sha512-jh9QqMPmAO4CLozGena08IPVnK95G7SwWKiVvMXVPQTxvPRfg8o0okmXvO55V2cMx/87H30AWMtRiNdE9Eoqfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2003.21",
-        "@babel/core": "7.28.3",
-        "@babel/helper-annotate-as-pure": "7.27.3",
-        "@babel/helper-split-export-declaration": "7.24.7",
-        "@inquirer/confirm": "5.1.14",
-        "@vitejs/plugin-basic-ssl": "2.1.0",
-        "beasties": "0.3.5",
-        "browserslist": "^4.23.0",
-        "esbuild": "0.25.9",
-        "https-proxy-agent": "7.0.6",
-        "istanbul-lib-instrument": "6.0.3",
-        "jsonc-parser": "3.3.1",
-        "listr2": "9.0.1",
-        "magic-string": "0.30.17",
-        "mrmime": "2.0.1",
-        "parse5-html-rewriting-stream": "8.0.0",
-        "picomatch": "4.0.3",
-        "piscina": "5.1.3",
-        "rollup": "4.59.0",
-        "sass": "1.90.0",
-        "semver": "7.7.2",
-        "source-map-support": "0.5.21",
-        "tinyglobby": "0.2.14",
-        "vite": "7.1.11",
-        "watchpack": "2.4.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "optionalDependencies": {
-        "lmdb": "3.4.2"
-      },
-      "peerDependencies": {
-        "@angular/compiler": "^20.0.0",
-        "@angular/compiler-cli": "^20.0.0",
-        "@angular/core": "^20.0.0",
-        "@angular/localize": "^20.0.0",
-        "@angular/platform-browser": "^20.0.0",
-        "@angular/platform-server": "^20.0.0",
-        "@angular/service-worker": "^20.0.0",
-        "@angular/ssr": "^20.3.21",
-        "karma": "^6.4.0",
-        "less": "^4.2.0",
-        "ng-packagr": "^20.0.0",
-        "postcss": "^8.4.0",
-        "tailwindcss": "^2.0.0 || ^3.0.0 || ^4.0.0",
-        "tslib": "^2.3.0",
-        "typescript": ">=5.8 <6.0",
-        "vitest": "^3.1.1"
-      },
-      "peerDependenciesMeta": {
-        "@angular/core": {
-          "optional": true
-        },
-        "@angular/localize": {
-          "optional": true
-        },
-        "@angular/platform-browser": {
-          "optional": true
-        },
-        "@angular/platform-server": {
-          "optional": true
-        },
-        "@angular/service-worker": {
-          "optional": true
-        },
-        "@angular/ssr": {
-          "optional": true
-        },
-        "karma": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "ng-packagr": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "tailwindcss": {
-          "optional": true
-        },
-        "vitest": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@angular/cli": {
-      "version": "20.3.21",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-20.3.21.tgz",
-      "integrity": "sha512-6i+qhtPsHk2uF4IoFi3Q9Rs4Wd2cxSodfND3wansld9MIRbTFDo8MGfhxaXqS0WwUlHZtp3Lt84q50xaF9Y7Yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/architect": "0.2003.21",
-        "@angular-devkit/core": "20.3.21",
-        "@angular-devkit/schematics": "20.3.21",
-        "@inquirer/prompts": "7.8.2",
-        "@listr2/prompt-adapter-inquirer": "3.0.1",
-        "@modelcontextprotocol/sdk": "1.26.0",
-        "@schematics/angular": "20.3.21",
-        "@yarnpkg/lockfile": "1.1.0",
-        "algoliasearch": "5.35.0",
-        "ini": "5.0.0",
-        "jsonc-parser": "3.3.1",
-        "listr2": "9.0.1",
-        "npm-package-arg": "13.0.0",
-        "pacote": "21.0.4",
-        "resolve": "1.22.10",
-        "semver": "7.7.2",
-        "yargs": "18.0.0",
-        "zod": "4.1.13"
-      },
-      "bin": {
-        "ng": "bin/ng.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular/cli/node_modules/@angular-devkit/core": {
-      "version": "20.3.21",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.21.tgz",
-      "integrity": "sha512-+flPAkPPn6MLVOa4ereSo6M5QRqxElKvDL6rCJWOJHRzH7K4CcfA269vr5mQSlImI5ZZc/EAPpm9rwEfWZRwew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "8.18.0",
-        "ajv-formats": "3.0.1",
-        "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.3",
-        "rxjs": "7.8.2",
-        "source-map": "0.7.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "chokidar": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "chokidar": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@angular/cli/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@angular/common": {
-      "version": "20.3.18",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.18.tgz",
-      "integrity": "sha512-M62oQbSTRmnGavIVCwimoadg/PDWadgNhactMm9fgH0eM9rx+iWBAYJk4VufO0bwOhysFpRZpJgXlFjOifz/Jw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "20.3.18",
-        "rxjs": "^6.5.3 || ^7.4.0"
-      }
-    },
-    "node_modules/@angular/compiler": {
-      "version": "20.3.18",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.18.tgz",
-      "integrity": "sha512-AaP/LCiDNcYmF135EEozjyR04NRBT38ZfBHQwjhgwiBBTejmvcpHwJaHSkraLpZqZzE4BQqqmgiQ1EJqxEwLVA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@angular/compiler-cli": {
-      "version": "20.3.18",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-20.3.18.tgz",
-      "integrity": "sha512-zsoEgLgnblmRbi47YwMghKirJ8IBKJ3+I8TxLBRIBrhx+KHFp+6oeDeLyu9H+djdyk88zexVd09wzR/YK73F0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "7.28.3",
-        "@jridgewell/sourcemap-codec": "^1.4.14",
-        "chokidar": "^4.0.0",
-        "convert-source-map": "^1.5.1",
-        "reflect-metadata": "^0.2.0",
-        "semver": "^7.0.0",
-        "tslib": "^2.3.0",
-        "yargs": "^18.0.0"
-      },
-      "bin": {
-        "ng-xi18n": "bundles/src/bin/ng_xi18n.js",
-        "ngc": "bundles/src/bin/ngc.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/compiler": "20.3.18",
-        "typescript": ">=5.8 <6.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@angular/core": {
-      "version": "20.3.18",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.18.tgz",
-      "integrity": "sha512-B+NQQngd/aDbcfW0zGLis3wTLDeHTeTYMl/mGKQH+HwdPaRCKI1wEtaXaOYVJXkP2FeThocPevB8gLwNlPQUUw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/compiler": "20.3.18",
-        "rxjs": "^6.5.3 || ^7.4.0",
-        "zone.js": "~0.15.0"
-      },
-      "peerDependenciesMeta": {
-        "@angular/compiler": {
-          "optional": true
-        },
-        "zone.js": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@angular/forms": {
-      "version": "20.3.18",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.3.18.tgz",
-      "integrity": "sha512-x6/99LfxolyZIFUL3Wr0OrtuXHEDwEz/rwx+WzE7NL+n35yO40t3kp0Sn5uMFwI94i91QZJmXHltMpZhrVLuYg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "20.3.18",
-        "@angular/core": "20.3.18",
-        "@angular/platform-browser": "20.3.18",
-        "rxjs": "^6.5.3 || ^7.4.0"
-      }
-    },
-    "node_modules/@angular/platform-browser": {
-      "version": "20.3.18",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.18.tgz",
-      "integrity": "sha512-q6s5rEN1yYazpHYp+k4pboXRzMsRB9auzTRBEhyXSGYxqzrnn3qHN0DqgsLC9WAdyhCgnIEMFA8kRT+W277DqQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/animations": "20.3.18",
-        "@angular/common": "20.3.18",
-        "@angular/core": "20.3.18"
-      },
-      "peerDependenciesMeta": {
-        "@angular/animations": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@angular/platform-browser-dynamic": {
-      "version": "20.3.19",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-20.3.19.tgz",
-      "integrity": "sha512-OgErw7wjcC+8yKF5h99hJq8x+tvc091wThfmdL5YC+U3HgRmUaNZFgB/jR7cb/NeeeC42QW5Vc0qoUTC9rMnLQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "20.3.19",
-        "@angular/compiler": "20.3.19",
-        "@angular/core": "20.3.19",
-        "@angular/platform-browser": "20.3.19"
-      }
-    },
-    "node_modules/@angular/router": {
-      "version": "20.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-20.3.3.tgz",
-      "integrity": "sha512-IrO5GY/vmaWwNdfR51xswNnBSxeEuvQAUqK3H0UNxhZlIE9gUS6pbbSidGGrQOZK+i0nd/rDz7j+RV7h2NK9aA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "20.3.3",
-        "@angular/core": "20.3.3",
-        "@angular/platform-browser": "20.3.3",
-        "rxjs": "^6.5.3 || ^7.4.0"
-      }
-    },
-    "node_modules/@arr/every": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@arr/every/-/every-1.0.1.tgz",
-      "integrity": "sha512-UQFQ6SgyJ6LX42W8rHCs8KVc0JS0tzVL9ct4XYedJukskYVWTo49tNiMEK9C2HTyarbNiT/RVIRSY82vH+6sTg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1519,42 +605,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.0.tgz",
-      "integrity": "sha512-BEOdvX4+M765icNPZeidyADIvQ1m1gmunXufXxvRESy/jNNyfovIqUyE7MVgGBjWktCoJlzvFA1To2O4ymIO3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-remap-async-to-generator": "^7.27.1",
-        "@babel/traverse": "^7.28.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-async-to-generator": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.27.1.tgz",
-      "integrity": "sha512-NREkZsZVJS4xmTr8qzE5y8AfIPqsdQfRuUiLRTEzb7Qii8iFWCyDKaUV2c0rCuh4ljDZ98ALHP/PetiBV2nddA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-remap-async-to-generator": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2180,37 +1230,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.3.tgz",
-      "integrity": "sha512-Y6ab1kGqZ0u42Zv/4a7l0l72n9DKP/MKoKWaUSBylrhNZO2prYuqFOLbn5aW5SIFXwSH93yfjbgllL8lxuGKLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "babel-plugin-polyfill-corejs2": "^0.4.14",
-        "babel-plugin-polyfill-corejs3": "^0.13.0",
-        "babel-plugin-polyfill-regenerator": "^0.6.5",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
@@ -2350,101 +1369,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/preset-env": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.3.tgz",
-      "integrity": "sha512-ROiDcM+GbYVPYBOeCR6uBXKkQpBExLl8k9HO1ygXEyds39j+vCCsjmj7S8GOniZQlEs81QlkdJZe76IpLSiqpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.28.0",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-validator-option": "^7.27.1",
-        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.27.1",
-        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
-        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.3",
-        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-        "@babel/plugin-syntax-import-assertions": "^7.27.1",
-        "@babel/plugin-syntax-import-attributes": "^7.27.1",
-        "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-        "@babel/plugin-transform-arrow-functions": "^7.27.1",
-        "@babel/plugin-transform-async-generator-functions": "^7.28.0",
-        "@babel/plugin-transform-async-to-generator": "^7.27.1",
-        "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
-        "@babel/plugin-transform-block-scoping": "^7.28.0",
-        "@babel/plugin-transform-class-properties": "^7.27.1",
-        "@babel/plugin-transform-class-static-block": "^7.28.3",
-        "@babel/plugin-transform-classes": "^7.28.3",
-        "@babel/plugin-transform-computed-properties": "^7.27.1",
-        "@babel/plugin-transform-destructuring": "^7.28.0",
-        "@babel/plugin-transform-dotall-regex": "^7.27.1",
-        "@babel/plugin-transform-duplicate-keys": "^7.27.1",
-        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.27.1",
-        "@babel/plugin-transform-dynamic-import": "^7.27.1",
-        "@babel/plugin-transform-explicit-resource-management": "^7.28.0",
-        "@babel/plugin-transform-exponentiation-operator": "^7.27.1",
-        "@babel/plugin-transform-export-namespace-from": "^7.27.1",
-        "@babel/plugin-transform-for-of": "^7.27.1",
-        "@babel/plugin-transform-function-name": "^7.27.1",
-        "@babel/plugin-transform-json-strings": "^7.27.1",
-        "@babel/plugin-transform-literals": "^7.27.1",
-        "@babel/plugin-transform-logical-assignment-operators": "^7.27.1",
-        "@babel/plugin-transform-member-expression-literals": "^7.27.1",
-        "@babel/plugin-transform-modules-amd": "^7.27.1",
-        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
-        "@babel/plugin-transform-modules-systemjs": "^7.27.1",
-        "@babel/plugin-transform-modules-umd": "^7.27.1",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.27.1",
-        "@babel/plugin-transform-new-target": "^7.27.1",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
-        "@babel/plugin-transform-numeric-separator": "^7.27.1",
-        "@babel/plugin-transform-object-rest-spread": "^7.28.0",
-        "@babel/plugin-transform-object-super": "^7.27.1",
-        "@babel/plugin-transform-optional-catch-binding": "^7.27.1",
-        "@babel/plugin-transform-optional-chaining": "^7.27.1",
-        "@babel/plugin-transform-parameters": "^7.27.7",
-        "@babel/plugin-transform-private-methods": "^7.27.1",
-        "@babel/plugin-transform-private-property-in-object": "^7.27.1",
-        "@babel/plugin-transform-property-literals": "^7.27.1",
-        "@babel/plugin-transform-regenerator": "^7.28.3",
-        "@babel/plugin-transform-regexp-modifiers": "^7.27.1",
-        "@babel/plugin-transform-reserved-words": "^7.27.1",
-        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
-        "@babel/plugin-transform-spread": "^7.27.1",
-        "@babel/plugin-transform-sticky-regex": "^7.27.1",
-        "@babel/plugin-transform-template-literals": "^7.27.1",
-        "@babel/plugin-transform-typeof-symbol": "^7.27.1",
-        "@babel/plugin-transform-unicode-escapes": "^7.27.1",
-        "@babel/plugin-transform-unicode-property-regex": "^7.27.1",
-        "@babel/plugin-transform-unicode-regex": "^7.27.1",
-        "@babel/plugin-transform-unicode-sets-regex": "^7.27.1",
-        "@babel/preset-modules": "0.1.6-no-external-plugins",
-        "babel-plugin-polyfill-corejs2": "^0.4.14",
-        "babel-plugin-polyfill-corejs3": "^0.13.0",
-        "babel-plugin-polyfill-regenerator": "^0.6.5",
-        "core-js-compat": "^3.43.0",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/preset-env/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/preset-modules": {
       "version": "0.1.6-no-external-plugins",
       "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
@@ -2457,16 +1381,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
-      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -5152,6 +4066,19 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/@candor-design/tokens/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@candor-design/tokens/node_modules/validate-npm-package-name": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
@@ -5744,757 +4671,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@compodoc/compodoc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@compodoc/compodoc/-/compodoc-1.2.1.tgz",
-      "integrity": "sha512-won7I0OeFM0zSi+cwVilwtLA7VpY9NzsBch6+gGElYQdbM4/01XgA//leF8EsNzhxuQb+kP86MqJ3loZhz+Big==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/schematics": "21.1.0",
-        "@babel/core": "7.28.6",
-        "@babel/plugin-transform-private-methods": "7.28.6",
-        "@babel/preset-env": "7.28.6",
-        "@compodoc/live-server": "^1.2.3",
-        "@compodoc/ngd-transformer": "^2.1.3",
-        "@polka/send-type": "^0.5.2",
-        "body-parser": "^2.2.2",
-        "bootstrap.native": "^5.1.6",
-        "cheerio": "1.1.2",
-        "chokidar": "^5.0.0",
-        "colors": "1.4.0",
-        "commander": "^14.0.2",
-        "cosmiconfig": "^9.0.0",
-        "decache": "^4.6.2",
-        "es6-shim": "^0.35.8",
-        "fancy-log": "^2.0.0",
-        "fast-glob": "^3.3.3",
-        "fs-extra": "^11.3.3",
-        "glob": "^13.0.0",
-        "handlebars": "^4.7.8",
-        "html-entities": "^2.6.0",
-        "i18next": "25.7.4",
-        "json5": "^2.2.3",
-        "lodash": "^4.17.21",
-        "loglevel": "^1.9.2",
-        "loglevel-plugin-prefix": "^0.8.4",
-        "lunr": "^2.3.9",
-        "marked": "7.0.3",
-        "minimist": "^1.2.8",
-        "neotraverse": "^0.6.18",
-        "opencollective-postinstall": "^2.0.3",
-        "os-name": "4.0.1",
-        "picocolors": "^1.1.1",
-        "polka": "^0.5.2",
-        "prismjs": "^1.30.0",
-        "semver": "^7.7.3",
-        "sirv": "^3.0.2",
-        "svg-pan-zoom": "^3.6.2",
-        "tablesort": "^5.7.0",
-        "ts-morph": "^27.0.2",
-        "uuid": "11.1.0",
-        "vis-network": "^10.0.2"
-      },
-      "bin": {
-        "compodoc": "bin/index-cli.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/@angular-devkit/core": {
-      "version": "21.1.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.1.0.tgz",
-      "integrity": "sha512-dPfVy0CictDjWffRv4pGTPOFjdlJL3ZkGUqxzaosUjMbJW+Ai9cNn1VNr7zxYZ4kem3BxLBh1thzDsCPrkXlZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "8.17.1",
-        "ajv-formats": "3.0.1",
-        "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.3",
-        "rxjs": "7.8.2",
-        "source-map": "0.7.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "chokidar": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "chokidar": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/@angular-devkit/schematics": {
-      "version": "21.1.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.1.0.tgz",
-      "integrity": "sha512-sVgTntCZCOV7mOpHzj6V14KOAoy4B9Ur9yHNRFZVgL2yD77TYRrJ0qwq+l7Im9fSjMCar6csjboqCvyAEpfV1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/core": "21.1.0",
-        "jsonc-parser": "3.3.1",
-        "magic-string": "0.30.21",
-        "ora": "9.0.0",
-        "rxjs": "7.8.2"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/@babel/core": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
-      "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/generator": "^7.28.6",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
-      "integrity": "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-remap-async-to-generator": "^7.27.1",
-        "@babel/traverse": "^7.29.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/@babel/plugin-transform-async-to-generator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
-      "integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-remap-async-to-generator": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/@babel/preset-env": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.6.tgz",
-      "integrity": "sha512-GaTI4nXDrs7l0qaJ6Rg06dtOXTBCG6TMDB44zbqofCIC4PqC7SEvmFFtpxzCDw9W5aJ7RKVshgXTLvLdBFV/qw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
-        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
-        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
-        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
-        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-        "@babel/plugin-syntax-import-assertions": "^7.28.6",
-        "@babel/plugin-syntax-import-attributes": "^7.28.6",
-        "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-        "@babel/plugin-transform-arrow-functions": "^7.27.1",
-        "@babel/plugin-transform-async-generator-functions": "^7.28.6",
-        "@babel/plugin-transform-async-to-generator": "^7.28.6",
-        "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
-        "@babel/plugin-transform-block-scoping": "^7.28.6",
-        "@babel/plugin-transform-class-properties": "^7.28.6",
-        "@babel/plugin-transform-class-static-block": "^7.28.6",
-        "@babel/plugin-transform-classes": "^7.28.6",
-        "@babel/plugin-transform-computed-properties": "^7.28.6",
-        "@babel/plugin-transform-destructuring": "^7.28.5",
-        "@babel/plugin-transform-dotall-regex": "^7.28.6",
-        "@babel/plugin-transform-duplicate-keys": "^7.27.1",
-        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.28.6",
-        "@babel/plugin-transform-dynamic-import": "^7.27.1",
-        "@babel/plugin-transform-explicit-resource-management": "^7.28.6",
-        "@babel/plugin-transform-exponentiation-operator": "^7.28.6",
-        "@babel/plugin-transform-export-namespace-from": "^7.27.1",
-        "@babel/plugin-transform-for-of": "^7.27.1",
-        "@babel/plugin-transform-function-name": "^7.27.1",
-        "@babel/plugin-transform-json-strings": "^7.28.6",
-        "@babel/plugin-transform-literals": "^7.27.1",
-        "@babel/plugin-transform-logical-assignment-operators": "^7.28.6",
-        "@babel/plugin-transform-member-expression-literals": "^7.27.1",
-        "@babel/plugin-transform-modules-amd": "^7.27.1",
-        "@babel/plugin-transform-modules-commonjs": "^7.28.6",
-        "@babel/plugin-transform-modules-systemjs": "^7.28.5",
-        "@babel/plugin-transform-modules-umd": "^7.27.1",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.27.1",
-        "@babel/plugin-transform-new-target": "^7.27.1",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6",
-        "@babel/plugin-transform-numeric-separator": "^7.28.6",
-        "@babel/plugin-transform-object-rest-spread": "^7.28.6",
-        "@babel/plugin-transform-object-super": "^7.27.1",
-        "@babel/plugin-transform-optional-catch-binding": "^7.28.6",
-        "@babel/plugin-transform-optional-chaining": "^7.28.6",
-        "@babel/plugin-transform-parameters": "^7.27.7",
-        "@babel/plugin-transform-private-methods": "^7.28.6",
-        "@babel/plugin-transform-private-property-in-object": "^7.28.6",
-        "@babel/plugin-transform-property-literals": "^7.27.1",
-        "@babel/plugin-transform-regenerator": "^7.28.6",
-        "@babel/plugin-transform-regexp-modifiers": "^7.28.6",
-        "@babel/plugin-transform-reserved-words": "^7.27.1",
-        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
-        "@babel/plugin-transform-spread": "^7.28.6",
-        "@babel/plugin-transform-sticky-regex": "^7.27.1",
-        "@babel/plugin-transform-template-literals": "^7.27.1",
-        "@babel/plugin-transform-typeof-symbol": "^7.27.1",
-        "@babel/plugin-transform-unicode-escapes": "^7.27.1",
-        "@babel/plugin-transform-unicode-property-regex": "^7.28.6",
-        "@babel/plugin-transform-unicode-regex": "^7.27.1",
-        "@babel/plugin-transform-unicode-sets-regex": "^7.28.6",
-        "@babel/preset-modules": "0.1.6-no-external-plugins",
-        "babel-plugin-polyfill-corejs2": "^0.4.14",
-        "babel-plugin-polyfill-corejs3": "^0.13.0",
-        "babel-plugin-polyfill-regenerator": "^0.6.5",
-        "core-js-compat": "^3.43.0",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/@babel/preset-env/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/cli-spinners": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
-      "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@compodoc/compodoc/node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/log-symbols": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
-      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0",
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/ora": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.0.0.tgz",
-      "integrity": "sha512-m0pg2zscbYgWbqRR6ABga5c3sZdEon7bSgjnlXC64kxtxLOyjRcbbUkLj7HFyy/FTD+P2xdBWu8snGhYI0jc4A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.6.2",
-        "cli-cursor": "^5.0.0",
-        "cli-spinners": "^3.2.0",
-        "is-interactive": "^2.0.0",
-        "is-unicode-supported": "^2.1.0",
-        "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.2.2",
-        "string-width": "^8.1.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/string-width": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@compodoc/compodoc/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
-    "node_modules/@compodoc/live-server": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@compodoc/live-server/-/live-server-1.2.3.tgz",
-      "integrity": "sha512-hDmntVCyjjaxuJzPzBx68orNZ7TW4BtHWMnXlIVn5dqhK7vuFF/11hspO1cMmc+2QTYgqde1TBcb3127S7Zrow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^3.5.2",
-        "colors": "1.4.0",
-        "connect": "^3.7.0",
-        "cors": "latest",
-        "event-stream": "4.0.1",
-        "faye-websocket": "0.11.x",
-        "http-auth": "4.1.9",
-        "http-auth-connect": "^1.0.5",
-        "morgan": "^1.10.0",
-        "object-assign": "latest",
-        "open": "8.4.0",
-        "proxy-middleware": "latest",
-        "send": "latest",
-        "serve-index": "^1.9.1"
-      },
-      "bin": {
-        "live-server": "live-server.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@compodoc/live-server/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/@compodoc/live-server/node_modules/define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@compodoc/live-server/node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@compodoc/live-server/node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@compodoc/live-server/node_modules/open": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@compodoc/live-server/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/@compodoc/live-server/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/@compodoc/ngd-core": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@compodoc/ngd-core/-/ngd-core-2.1.1.tgz",
-      "integrity": "sha512-Z+wE6wWZYVnudRYg6qunDlyh3Orw39Ib66Gvrz5kX5u7So+iu3tr6sQJdqH6yGS3hAjig5avlfhWLlgsb6/x1Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-colors": "^4.1.3",
-        "fancy-log": "^2.0.0",
-        "typescript": "^5.0.4"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@compodoc/ngd-transformer": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@compodoc/ngd-transformer/-/ngd-transformer-2.1.3.tgz",
-      "integrity": "sha512-oWxJza7CpWR8/FeWYfE6j+jgncnGBsTWnZLt5rD2GUpsGSQTuGrsFPnmbbaVLgRS5QIVWBJYke7QFBr/7qVMWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@aduh95/viz.js": "3.4.0",
-        "@compodoc/ngd-core": "~2.1.1",
-        "dot": "^2.0.0-beta.1",
-        "fs-extra": "^11.1.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@compodoc/ngd-transformer/node_modules/fs-extra": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
-      "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@compodoc/ngd-transformer/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@compodoc/ngd-transformer/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -7094,28 +5270,6 @@
         }
       }
     },
-    "node_modules/@inquirer/confirm": {
-      "version": "5.1.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.14.tgz",
-      "integrity": "sha512-5yR4IBfe0kXe59r1YCTG8WXkUbl7Z35HK87Sw+WUyGD8wNUx7JvY7laahzeytyE1oLn74bQnL7hstctQxisQ8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/type": "^3.0.8"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@inquirer/core": {
       "version": "10.3.2",
       "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
@@ -7268,36 +5422,6 @@
         "@inquirer/ansi": "^1.0.2",
         "@inquirer/core": "^10.3.2",
         "@inquirer/type": "^3.0.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/prompts": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.8.2.tgz",
-      "integrity": "sha512-nqhDw2ZcAUrKNPwhjinJny903bRhI0rQhiDz1LksjeRxqa36i3l75+4iXbOy0rlDpLJGxqtgoPavQjmmyS5UJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/checkbox": "^4.2.1",
-        "@inquirer/confirm": "^5.1.14",
-        "@inquirer/editor": "^4.2.17",
-        "@inquirer/expand": "^4.0.17",
-        "@inquirer/input": "^4.2.1",
-        "@inquirer/number": "^3.0.17",
-        "@inquirer/password": "^4.0.17",
-        "@inquirer/rawlist": "^4.1.5",
-        "@inquirer/search": "^3.1.0",
-        "@inquirer/select": "^4.3.1"
       },
       "engines": {
         "node": ">=18"
@@ -7871,120 +5995,20 @@
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "license": "MIT"
     },
-    "node_modules/@listr2/prompt-adapter-inquirer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@listr2/prompt-adapter-inquirer/-/prompt-adapter-inquirer-3.0.1.tgz",
-      "integrity": "sha512-3XFmGwm3u6ioREG+ynAQB7FoxfajgQnMhIu8wC5eo/Lsih4aKDg0VuIMGaOsYn7hJSJagSeaD4K8yfpkEoDEmA==",
-      "dev": true,
-      "license": "MIT",
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@inquirer/type": "^3.0.7"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@inquirer/prompts": ">= 3 < 8",
-        "listr2": "9.0.1"
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
-    },
-    "node_modules/@lmdb/lmdb-darwin-arm64": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-3.4.2.tgz",
-      "integrity": "sha512-NK80WwDoODyPaSazKbzd3NEJ3ygePrkERilZshxBViBARNz21rmediktGHExoj9n5t9+ChlgLlxecdFKLCuCKg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@lmdb/lmdb-darwin-x64": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-3.4.2.tgz",
-      "integrity": "sha512-zevaowQNmrp3U7Fz1s9pls5aIgpKRsKb3dZWDINtLiozh3jZI9fBrI19lYYBxqdyiIyNdlyiidPnwPShj4aK+w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@lmdb/lmdb-linux-arm": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-3.4.2.tgz",
-      "integrity": "sha512-OmHCULY17rkx/RoCoXlzU7LyR8xqrksgdYWwtYa14l/sseezZ8seKWXcogHcjulBddER5NnEFV4L/Jtr2nyxeg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@lmdb/lmdb-linux-arm64": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-3.4.2.tgz",
-      "integrity": "sha512-ZBEfbNZdkneebvZs98Lq30jMY8V9IJzckVeigGivV7nTHJc+89Ctomp1kAIWKlwIG0ovCDrFI448GzFPORANYg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@lmdb/lmdb-linux-x64": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-3.4.2.tgz",
-      "integrity": "sha512-vL9nM17C77lohPYE4YaAQvfZCSVJSryE4fXdi8M7uWPBnU+9DJabgKVAeyDb84ZM2vcFseoBE4/AagVtJeRE7g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@lmdb/lmdb-win32-arm64": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-arm64/-/lmdb-win32-arm64-3.4.2.tgz",
-      "integrity": "sha512-SXWjdBfNDze4ZPeLtYIzsIeDJDJ/SdsA0pEXcUBayUIMO0FQBHfVZZyHXQjjHr4cvOAzANBgIiqaXRwfMhzmLw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@lmdb/lmdb-win32-x64": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-3.4.2.tgz",
-      "integrity": "sha512-IY+r3bxKW6Q6sIPiMC0L533DEfRJSXibjSI3Ft/w9Q8KQBNqEIvUFXt+09wV8S5BRk0a8uSF19YWxuRwEfI90g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@mdx-js/react": {
       "version": "3.1.1",
@@ -8443,23 +6467,6 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
-    "node_modules/@ngtools/webpack": {
-      "version": "20.3.21",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-20.3.21.tgz",
-      "integrity": "sha512-qO6tit1mm4bGTMT1ZL6RTQMiQvck1aQymTiuUSa9lYg5ZRGL/v9WhKVx9+ncf9yrq2kj28LEAVJcAtrEEd/YJA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "@angular/compiler-cli": "^20.0.0",
-        "typescript": ">=5.8 <6.0",
-        "webpack": "^5.54.0"
-      }
-    },
     "node_modules/@noble/hashes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
@@ -8470,44 +6477,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/@npmcli/agent": {
@@ -8844,6 +6813,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8864,6 +6834,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8884,6 +6855,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8904,6 +6876,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8924,6 +6897,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8944,6 +6918,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8964,6 +6939,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8984,6 +6960,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9004,6 +6981,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9024,6 +7002,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9044,6 +7023,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9064,6 +7044,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9084,6 +7065,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9273,20 +7255,6 @@
       "engines": {
         "node": ">=20.0.0"
       }
-    },
-    "node_modules/@polka/send-type": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@polka/send-type/-/send-type-0.5.2.tgz",
-      "integrity": "sha512-jGXalKihnhGQmMQ+xxfxrRfI2cWs38TIZuwgYpnbQDD4r9TkOiU3ocjAS+6CqqMNQNAu9Ul2iHU5YFRDODak2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@polka/url": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-0.5.0.tgz",
-      "integrity": "sha512-oZLYFEAzUKyi3SKnXvj32ZCEGH6RDnao7COuCVhDydMS9NrCSVXhM79VaKyP5+Zc33m0QXEd2DN3UkU7OsHcfw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.4",
@@ -9587,9 +7555,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9602,9 +7567,6 @@
       "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9619,9 +7581,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9634,9 +7593,6 @@
       "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9651,9 +7607,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9666,9 +7619,6 @@
       "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9683,9 +7633,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9698,9 +7645,6 @@
       "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9715,9 +7659,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9730,9 +7671,6 @@
       "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9747,9 +7685,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9763,9 +7698,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9778,9 +7710,6 @@
       "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9866,68 +7795,6 @@
         "win32"
       ]
     },
-    "node_modules/@schematics/angular": {
-      "version": "20.3.21",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-20.3.21.tgz",
-      "integrity": "sha512-RzF+y4QOrerJ8H/7DrAnP/T3TzHeaNuBx5JweYYOwyx2/caDxN5uwjw/rQnUpQwUlSaM8NKve9FETUn7E7t0pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@angular-devkit/core": "20.3.21",
-        "@angular-devkit/schematics": "20.3.21",
-        "jsonc-parser": "3.3.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@schematics/angular/node_modules/@angular-devkit/core": {
-      "version": "20.3.21",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.21.tgz",
-      "integrity": "sha512-+flPAkPPn6MLVOa4ereSo6M5QRqxElKvDL6rCJWOJHRzH7K4CcfA269vr5mQSlImI5ZZc/EAPpm9rwEfWZRwew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "8.18.0",
-        "ajv-formats": "3.0.1",
-        "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.3",
-        "rxjs": "7.8.2",
-        "source-map": "0.7.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "chokidar": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "chokidar": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@schematics/angular/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@sigstore/bundle": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
@@ -10011,13 +7878,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@socket.io/component-emitter": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
-      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -10025,16 +7885,16 @@
       "license": "MIT"
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.10.tgz",
-      "integrity": "sha512-LYK3oXy/0PgY39FhkYVd9D0bzatLGTsMhaPPwSjBOmZgK0f0yBLqaePy7urUFeHYm/rjwAaRmDJNBqUnGTVoig==",
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-8.6.18.tgz",
+      "integrity": "sha512-55ADer0yNmmeR928Y3UAv3r4i7bJSd9LwywsQ+lRol/FNe0ZcwLEz31xL+jVsqQFNnDh/imsDIp8aYapGMtfEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/csf-plugin": "9.1.10",
-        "@storybook/icons": "^1.4.0",
-        "@storybook/react-dom-shim": "9.1.10",
+        "@storybook/blocks": "8.6.18",
+        "@storybook/csf-plugin": "8.6.18",
+        "@storybook/react-dom-shim": "8.6.18",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -10044,191 +7904,17 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.10"
+        "storybook": "^8.6.18"
       }
     },
-    "node_modules/@storybook/angular": {
-      "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/angular/-/angular-9.1.10.tgz",
-      "integrity": "sha512-VcDsvBazgyAP7QZySe5inlDAghz6fdCIc7AruXdgv/WzjMnhiTqeryCMRyZt4azD9fpjZf2L6CofbgWlRqFTjg==",
+    "node_modules/@storybook/blocks": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-8.6.18.tgz",
+      "integrity": "sha512-esZv4msPQ9LxgTb8YUIZhhxVMuI6BPi5bkXtk8c7w7sWuAsqsCe/RnVInn7ooUry2gjnD4hd9+8Eqj0b8oTVoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/builder-webpack5": "9.1.10",
-        "@storybook/global": "^5.0.0",
-        "telejson": "8.0.0",
-        "ts-dedent": "^2.0.0",
-        "tsconfig-paths-webpack-plugin": "^4.0.1",
-        "webpack": "5"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "@angular-devkit/architect": ">=0.1800.0 < 0.2100.0",
-        "@angular-devkit/build-angular": ">=18.0.0 < 21.0.0",
-        "@angular-devkit/core": ">=18.0.0 < 21.0.0",
-        "@angular/animations": ">=18.0.0 < 21.0.0",
-        "@angular/cli": ">=18.0.0 < 21.0.0",
-        "@angular/common": ">=18.0.0 < 21.0.0",
-        "@angular/compiler": ">=18.0.0 < 21.0.0",
-        "@angular/compiler-cli": ">=18.0.0 < 21.0.0",
-        "@angular/core": ">=18.0.0 < 21.0.0",
-        "@angular/forms": ">=18.0.0 < 21.0.0",
-        "@angular/platform-browser": ">=18.0.0 < 21.0.0",
-        "@angular/platform-browser-dynamic": ">=18.0.0 < 21.0.0",
-        "rxjs": "^6.5.3 || ^7.4.0",
-        "storybook": "^9.1.10",
-        "typescript": "^4.9.0 || ^5.0.0",
-        "zone.js": ">=0.14.0"
-      },
-      "peerDependenciesMeta": {
-        "@angular/animations": {
-          "optional": true
-        },
-        "@angular/cli": {
-          "optional": true
-        },
-        "zone.js": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@storybook/builder-webpack5": {
-      "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-9.1.10.tgz",
-      "integrity": "sha512-6Cw0lJ0SxGPGhBPx5zOozxEtu7Nm3rOMCuYGQy3OYUbAmznk82NB6pnQ4cdCIBmX61ZyGykhXShLjtCWHh/8tw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/core-webpack": "9.1.10",
-        "case-sensitive-paths-webpack-plugin": "^2.4.0",
-        "cjs-module-lexer": "^1.2.3",
-        "css-loader": "^6.7.1",
-        "es-module-lexer": "^1.5.0",
-        "fork-ts-checker-webpack-plugin": "^8.0.0",
-        "html-webpack-plugin": "^5.5.0",
-        "magic-string": "^0.30.5",
-        "style-loader": "^3.3.1",
-        "terser-webpack-plugin": "^5.3.1",
-        "ts-dedent": "^2.0.0",
-        "webpack": "5",
-        "webpack-dev-middleware": "^6.1.2",
-        "webpack-hot-middleware": "^2.25.1",
-        "webpack-virtual-modules": "^0.6.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^9.1.10"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@storybook/builder-webpack5/node_modules/css-loader": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.11.0.tgz",
-      "integrity": "sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "icss-utils": "^5.1.0",
-        "postcss": "^8.4.33",
-        "postcss-modules-extract-imports": "^3.1.0",
-        "postcss-modules-local-by-default": "^4.0.5",
-        "postcss-modules-scope": "^3.2.0",
-        "postcss-modules-values": "^4.0.0",
-        "postcss-value-parser": "^4.2.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@rspack/core": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@storybook/builder-webpack5/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@storybook/builder-webpack5/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@storybook/builder-webpack5/node_modules/webpack-dev-middleware": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-6.1.3.tgz",
-      "integrity": "sha512-A4ChP0Qj8oGociTs6UdlRUGANIGrCDL3y+pmQMc+dSsraXHCatFpmMey4mYELA+juqwUqwQsUgJJISXl1KWmiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "colorette": "^2.0.10",
-        "memfs": "^3.4.12",
-        "mime-types": "^2.1.31",
-        "range-parser": "^1.2.1",
-        "schema-utils": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@storybook/core-webpack": {
-      "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-9.1.10.tgz",
-      "integrity": "sha512-zborBOQtZBkGl0NcOgNygRdiPFqseh9UnLWVV1yLZglCZN5BTnXjEGhpRFHBOhPux3gdHNcvrvgYSgcitFpEPA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
+        "@storybook/icons": "^1.2.12",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -10236,13 +7922,89 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.10"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^8.6.18"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/builder-vite": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-8.6.18.tgz",
+      "integrity": "sha512-XLqnOv4C36jlTd4uC8xpWBxv+7GV4/05zWJ0wAcU4qflorropUTirt4UQPGkwIzi+BVAhs9pJj+m4k0IWJtpHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/csf-plugin": "8.6.18",
+        "browser-assert": "^1.2.1",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.18",
+        "vite": "^4.0.0 || ^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@storybook/components": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.6.18.tgz",
+      "integrity": "sha512-55yViiZzPS/cPBuOeW4QGxGqrusjXVyxuknmbYCIwDtFyyvI/CgbjXRHdxNBaIjz+IlftxvBmmSaOqFG5+/dkA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
+      }
+    },
+    "node_modules/@storybook/core": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.6.18.tgz",
+      "integrity": "sha512-dRBP2TnX6fGdS0T2mXBHjkS/3Nlu1ra1huovZVFuM67CYMzrhM/3hX/zru1vWSC5rqY93ZaAhjMciPW4pK5mMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/theming": "8.6.18",
+        "better-opn": "^3.0.2",
+        "browser-assert": "^1.2.1",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0",
+        "esbuild-register": "^3.5.0",
+        "jsdoc-type-pratt-parser": "^4.0.0",
+        "process": "^0.11.10",
+        "recast": "^0.23.5",
+        "semver": "^7.6.2",
+        "util": "^0.12.5",
+        "ws": "^8.2.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "prettier": "^2 || ^3"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        }
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.10.tgz",
-      "integrity": "sha512-247F/JU0Naxm/RIUnQYpqXeCL0wG8UNJkZe+/GkLjdqzsyML0lb+8OwBsWFfG8zfj6fkjmRU2mF44TnNkzoQcg==",
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.6.18.tgz",
+      "integrity": "sha512-x1ioz/L0CwaelCkHci3P31YtvwayN3FBftvwQOPbvRh9qeb4Cpz5IdVDmyvSxxYwXN66uAORNoqgjTi7B4/y5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10253,7 +8015,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.10"
+        "storybook": "^8.6.18"
       }
     },
     "node_modules/@storybook/global": {
@@ -10277,10 +8039,38 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta"
       }
     },
+    "node_modules/@storybook/manager-api": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.6.18.tgz",
+      "integrity": "sha512-BjIp12gEMgzFkEsgKpDIbZdnSWTZpm2dlws8WiPJCpgJtG+HWSxZ0/Ms30Au9yfwzQEKRSbV/5zpsKMGc2SIJw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
+      }
+    },
+    "node_modules/@storybook/preview-api": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.6.18.tgz",
+      "integrity": "sha512-joXRXh3GdVvzhbfIgmix1xs90p8Q/nja7AhEAC2egn5Pl7SKsIYZUCYI6UdrQANb2myg9P552LKXfPect8llKg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
+      }
+    },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.10.tgz",
-      "integrity": "sha512-cxy8GTj73RMJIFPrgqdnMXePGX5iFohM5pDCZ63Te5m5GtzKqsILRXtBBLO6Ouexm/ZYRVznkKiwNKX/Fu24fQ==",
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.6.18.tgz",
+      "integrity": "sha512-N4xULcAWZQTUv4jy1/d346Tyb4gufuC3UaLCuU/iVSZ1brYF4OW3ANr+096btbMxY8pR/65lmtoqr5CTGwnBvA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -10290,135 +8080,70 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.10"
+        "storybook": "^8.6.18"
       }
     },
-    "node_modules/@testing-library/jest-dom": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
-      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+    "node_modules/@storybook/theming": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.18.tgz",
+      "integrity": "sha512-n6OEjEtHupa2PdTwWzRepr7cO8NkDd4rgF6BKLitRbujOspLxzMBEqdphs+QLcuiCIgf33SqmEA64QWnbSMhPw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@adobe/css-tools": "^4.4.0",
-        "aria-query": "^5.0.0",
-        "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.6.3",
-        "picocolors": "^1.1.1",
-        "redent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
-      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@testing-library/user-event": {
-      "version": "14.6.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
-      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "@testing-library/dom": ">=7.21.4"
+        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
       }
     },
-    "node_modules/@thednp/event-listener": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@thednp/event-listener/-/event-listener-2.0.10.tgz",
-      "integrity": "sha512-TH7YVKmoKg6GBLqZB+ETXObofcqJ/Tp5ycheolvYZMjLbMpzYf6MmOWTcBtx8+zrhWy8deV0hYkPvDFioDXdVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16",
-        "pnpm": ">=8.6.0"
-      }
-    },
-    "node_modules/@thednp/position-observer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@thednp/position-observer/-/position-observer-1.1.0.tgz",
-      "integrity": "sha512-WgldP6Dltp2hJkSwp3+IVu05ClK/2IF33iftiQLb7UHcuO6eydjXiIUeOCClgCy3FDCGau2l/LRVg3oOO3Ytcg==",
+    "node_modules/@storybook/web-components": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/web-components/-/web-components-8.6.18.tgz",
+      "integrity": "sha512-keHYAuFQtixM9fOYO022Yc6zslqc1UpxNTFR/NkWo4Bn/o7CLQKv2L9rbmZrCWyV0HsZgxvsvI3OPlRSqkksVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@thednp/shorty": "^2.0.11"
+        "@storybook/components": "8.6.18",
+        "@storybook/global": "^5.0.0",
+        "@storybook/manager-api": "8.6.18",
+        "@storybook/preview-api": "8.6.18",
+        "@storybook/theming": "8.6.18",
+        "tiny-invariant": "^1.3.1",
+        "ts-dedent": "^2.0.0"
       },
       "engines": {
-        "node": ">=16",
-        "pnpm": ">=8.6.0"
-      }
-    },
-    "node_modules/@thednp/shorty": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@thednp/shorty/-/shorty-2.0.11.tgz",
-      "integrity": "sha512-D+rLHt1l7c608yCuzXYJ75aDNWeMVbor+m1HO/XibhiWRbCpD8r6TUv3ayJI+feVfCnBNfrH+p6LSDn9l99uBA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16",
-        "pnpm": ">=8.6.0"
-      }
-    },
-    "node_modules/@ts-morph/common": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
-      "integrity": "sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimatch": "^10.0.1",
-        "path-browserify": "^1.0.1",
-        "tinyglobby": "^0.2.14"
-      }
-    },
-    "node_modules/@ts-morph/common/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@ts-morph/common/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
+        "node": ">=18.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "lit": "^2.0.0 || ^3.0.0",
+        "storybook": "^8.6.18"
+      }
+    },
+    "node_modules/@storybook/web-components-vite": {
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/web-components-vite/-/web-components-vite-8.6.18.tgz",
+      "integrity": "sha512-Nls1FBb4vYkrbJJ/ojleR7zLFoRPSmG/twNPj36YP50iGWHy12H5+eJ8kRDzNXPma9HICHdzKYOTSmOar86jjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/builder-vite": "8.6.18",
+        "@storybook/web-components": "8.6.18",
+        "magic-string": "^0.30.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.6.18"
       }
     },
     "node_modules/@tufjs/canonical-json": {
@@ -10509,13 +8234,14 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
-      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/deep-eql": "*"
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/connect": {
@@ -10534,16 +8260,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/express-serve-static-core": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/cors": {
-      "version": "2.8.19",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
-      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -10895,13 +8611,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/html-minifier-terser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
-      "integrity": "sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -10916,13 +8625,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/jasmine": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-5.1.9.tgz",
-      "integrity": "sha512-8t4HtkW4wxiPVedMpeZ63n3vlWxEIquo/zc1Tm8ElU+SqVV7+D3Na2PWaJUp179AzTragMWVwkMv7mvty0NfyQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -10968,23 +8670,6 @@
       "dependencies": {
         "undici-types": "~7.13.0"
       }
-    },
-    "node_modules/@types/node-forge": {
-      "version": "1.3.14",
-      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
-      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
-      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/qs": {
       "version": "6.14.0",
@@ -11052,6 +8737,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -11059,19 +8750,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@vitejs/plugin-basic-ssl": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.1.0.tgz",
-      "integrity": "sha512-dOxxrhgyDIEUADhb/8OlV9JIqYLgos03YorAueTIeOUskLJSEsfwCByjbu98ctXitUN3znXKp0bYD/WHSudCeA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "peerDependencies": {
-        "vite": "^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -11126,6 +8804,36 @@
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -11450,32 +9158,6 @@
         "ajv": "^8.8.2"
       }
     },
-    "node_modules/algoliasearch": {
-      "version": "5.35.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.35.0.tgz",
-      "integrity": "sha512-Y+moNhsqgLmvJdgTsO4GZNgsaDWv8AOGAaPeIeHKlDn/XunoAqYbA+XNpBd1dW8GOXAUDyxC9Rxc7AV4kpFcIg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/abtesting": "1.1.0",
-        "@algolia/client-abtesting": "5.35.0",
-        "@algolia/client-analytics": "5.35.0",
-        "@algolia/client-common": "5.35.0",
-        "@algolia/client-insights": "5.35.0",
-        "@algolia/client-personalization": "5.35.0",
-        "@algolia/client-query-suggestions": "5.35.0",
-        "@algolia/client-search": "5.35.0",
-        "@algolia/ingestion": "1.35.0",
-        "@algolia/monitoring": "1.35.0",
-        "@algolia/recommend": "5.35.0",
-        "@algolia/requester-browser-xhr": "5.35.0",
-        "@algolia/requester-fetch": "5.35.0",
-        "@algolia/requester-node-http": "5.35.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -11561,29 +9243,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/apache-crypt": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/apache-crypt/-/apache-crypt-1.2.6.tgz",
-      "integrity": "sha512-072WetlM4blL8PREJVeY+WHiUh1R5VNt2HfceGS8aKqttPHcmqE5pkKuXPz/ULmJOFkc8Hw3kfKl6vy7Qka6DA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unix-crypt-td-js": "^1.1.4"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/apache-md5": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/apache-md5/-/apache-md5-1.1.8.tgz",
-      "integrity": "sha512-FCAJojipPn0bXjuEpjOOOMN8FZDkxfWWp4JGN9mifU2IhxvKyXZYqpzPHdnTSUpmPDy+tsslB6Z1g+Vg6nVbYA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/apca-w3": {
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/apca-w3/-/apca-w3-0.1.9.tgz",
@@ -11598,16 +9257,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
-    },
-    "node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "dequal": "^2.0.3"
-      }
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -11652,42 +9301,20 @@
         "node": ">=4"
       }
     },
-    "node_modules/autoprefixer": {
-      "version": "10.4.21",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
-      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.24.4",
-        "caniuse-lite": "^1.0.30001702",
-        "fraction.js": "^4.3.7",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.1.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
+        "possible-typed-array-names": "^1.0.0"
       },
       "engines": {
-        "node": "^10 || ^12 || >=14"
+        "node": ">= 0.4"
       },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/babel-loader": {
@@ -11754,23 +9381,6 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/base64id": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^4.5.0 || >= 5.9"
-      }
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.10",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
@@ -11783,58 +9393,11 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/basic-auth/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
       "license": "MIT"
-    },
-    "node_modules/bcryptjs": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
-      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/beasties": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/beasties/-/beasties-0.3.5.tgz",
-      "integrity": "sha512-NaWu+f4YrJxEttJSm16AzMIFtVldCvaJ68b1L098KpqXmxt9xOLtKoLkKxb8ekhOrLqEJAbvT6n6SEvB/sac7A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "css-select": "^6.0.0",
-        "css-what": "^7.0.0",
-        "dom-serializer": "^2.0.0",
-        "domhandler": "^5.0.3",
-        "htmlparser2": "^10.0.0",
-        "picocolors": "^1.1.1",
-        "postcss": "^8.4.49",
-        "postcss-media-query-parser": "^0.2.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/better-opn": {
       "version": "3.0.2",
@@ -11967,33 +9530,6 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
     },
-    "node_modules/bootstrap.native": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/bootstrap.native/-/bootstrap.native-5.1.6.tgz",
-      "integrity": "sha512-bLveDBWhNLoFLsPctVo6yxSRQ1ysmKHBa+1FFMTQuruzTb3y7/InGSoe5lZdOiqZ4L0UOzpdbXMsI+bA5DoRew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@thednp/event-listener": "^2.0.10",
-        "@thednp/position-observer": "^1.1.0",
-        "@thednp/shorty": "^2.0.11"
-      },
-      "engines": {
-        "node": ">=16",
-        "pnpm": ">=8.6.0"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -12014,6 +9550,12 @@
       "dependencies": {
         "colorparsley": "^0.1.6"
       }
+    },
+    "node_modules/browser-assert": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
+      "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
+      "dev": true
     },
     "node_modules/browserslist": {
       "version": "4.28.1",
@@ -12085,6 +9627,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cacache": {
@@ -12170,6 +9722,25 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -12199,15 +9770,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/callsite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -12215,17 +9777,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/caniuse-lite": {
@@ -12247,16 +9798,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/case-sensitive-paths-webpack-plugin": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.4.0.tgz",
-      "integrity": "sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/chai": {
       "version": "5.3.3",
@@ -12294,113 +9835,13 @@
       "license": "MIT"
     },
     "node_modules/check-error": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 16"
-      }
-    },
-    "node_modules/cheerio": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
-      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cheerio-select": "^2.1.0",
-        "dom-serializer": "^2.0.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.2",
-        "encoding-sniffer": "^0.2.1",
-        "htmlparser2": "^10.0.0",
-        "parse5": "^7.3.0",
-        "parse5-htmlparser2-tree-adapter": "^7.1.0",
-        "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.12.0",
-        "whatwg-mimetype": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=20.18.1"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-      }
-    },
-    "node_modules/cheerio-select": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-select": "^5.1.0",
-        "css-what": "^6.1.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cheerio-select/node_modules/css-select": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cheerio-select/node_modules/css-what": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cheerio/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/cheerio/node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/chokidar": {
@@ -12437,36 +9878,6 @@
         "node": ">=6.0"
       }
     },
-    "node_modules/cjs-module-lexer": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
-      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/clean-css": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
-      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 10.0"
-      }
-    },
-    "node_modules/clean-css/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -12474,36 +9885,6 @@
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
-      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "slice-ansi": "^5.0.0",
-        "string-width": "^7.0.0"
       },
       "engines": {
         "node": ">=18"
@@ -12578,13 +9959,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/code-block-writer": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
-      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -12603,16 +9977,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
@@ -12630,26 +9994,6 @@
       "resolved": "https://registry.npmjs.org/colorparsley/-/colorparsley-0.1.8.tgz",
       "integrity": "sha512-rObESTTTE6G5qO5WFwFxWPggpw4KfpxnLC6Ssl8bITBnNVRhDsyCeTRAUxWQNVTx2pRknKlO2nddYTxjkdNFaw==",
       "license": "AGPL v3"
-    },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -12705,29 +10049,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/connect": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
-      "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "finalhandler": "1.1.2",
-        "parseurl": "~1.3.3",
-        "utils-merge": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
@@ -12735,75 +10056,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/connect/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/connect/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/connect/node_modules/finalhandler": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
-        "statuses": "~1.5.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/connect/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/connect/node_modules/on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/connect/node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -12971,42 +10223,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-loader": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.2.tgz",
-      "integrity": "sha512-6WvYYn7l/XEGN8Xu2vWFt9nVzrCn39vKyTEFf/ExEyoksJjjSZV/0/35XPlMbpnr6VGhZIUg5yJrL8tGfes/FA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "icss-utils": "^5.1.0",
-        "postcss": "^8.4.33",
-        "postcss-modules-extract-imports": "^3.1.0",
-        "postcss-modules-local-by-default": "^4.0.5",
-        "postcss-modules-scope": "^3.2.0",
-        "postcss-modules-values": "^4.0.0",
-        "postcss-value-parser": "^4.2.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
-        "webpack": "^5.27.0"
-      },
-      "peerDependenciesMeta": {
-        "@rspack/core": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/css-select": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-6.0.0.tgz",
@@ -13035,13 +10251,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/css.escape": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -13053,13 +10262,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/custom-event": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
-      "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/d3": {
       "version": "7.9.0",
@@ -13483,16 +10685,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/date-format": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
-      "integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -13510,16 +10702,6 @@
         }
       }
     },
-    "node_modules/decache": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/decache/-/decache-4.6.2.tgz",
-      "integrity": "sha512-2LPqkLeu8XWHU8qNCS3kcF6sCcb5zIzvWaAHYSvPfwhdd7mHuah29NssMzrTYyHN4F5oFy2ko9OBYxegtU0FEw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsite": "^1.0.0"
-      }
-    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -13528,16 +10710,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/default-browser": {
@@ -13566,6 +10738,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-lazy-prop": {
@@ -13598,16 +10788,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -13634,13 +10814,6 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "license": "MIT"
     },
-    "node_modules/di": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
-      "integrity": "sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/dns-packet": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
@@ -13651,29 +10824,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/dom-converter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
-      "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "utila": "~0.4"
-      }
-    },
-    "node_modules/dom-serialize": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
-      "integrity": "sha512-Yra4DbvoW7/Z6LBN560ZwXMjoNOSAN2wRsKFGc4iBeso+mpIA6qj1vfdf9HpMaKAqG6wXTy+1SYEzmNpKXOSsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "custom-event": "~1.0.0",
-        "ent": "~2.2.0",
-        "extend": "^3.0.0",
-        "void-elements": "^2.0.0"
       }
     },
     "node_modules/dom-serializer": {
@@ -13731,24 +10881,6 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
-    "node_modules/dot": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/dot/-/dot-2.0.0-beta.1.tgz",
-      "integrity": "sha512-kxM7fSnNQTXOmaeGuBSXM8O3fEsBb7XSDBllkGbRwa0lJSJTxxDE/4eSNGLKZUmlFw0f1vJ5qSV2BljrgQtgIA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -13762,13 +10894,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -13806,139 +10931,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/encoding-sniffer": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
-      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "^0.6.3",
-        "whatwg-encoding": "^3.1.1"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
-      }
-    },
-    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
-    "node_modules/engine.io": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
-      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/cors": "^2.8.12",
-        "@types/node": ">=10.0.0",
-        "accepts": "~1.3.4",
-        "base64id": "2.0.0",
-        "cookie": "~0.7.2",
-        "cors": "~2.8.5",
-        "debug": "~4.3.1",
-        "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1"
-      },
-      "engines": {
-        "node": ">=10.2.0"
-      }
-    },
-    "node_modules/engine.io-parser": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
-      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/engine.io/node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/engine.io/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/engine.io/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/engine.io/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/engine.io/node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
@@ -13950,22 +10942,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/ent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.2.tgz",
-      "integrity": "sha512-kKvD1tO6BM+oK9HzCPpUdRb4vKFQY/FPTFmurMvh6LlN68VMrdj77w8yp51/kDbpkFOS9J8w5W6zIzgM2H8/hw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "punycode": "^1.4.1",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/entities": {
@@ -14066,13 +11042,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es6-shim": {
-      "version": "0.35.8",
-      "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.8.tgz",
-      "integrity": "sha512-Twf7I2v4/1tLoIXMT8HlqaBSS5H2wQTs2wx3MNYCI8K1R1/clXyCazrcVCPm/FuO9cyV8+leEaZOWD5C253NDg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/esbuild": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
@@ -14126,19 +11095,6 @@
       },
       "peerDependencies": {
         "esbuild": ">=0.12 <1"
-      }
-    },
-    "node_modules/esbuild-wasm": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/esbuild-wasm/-/esbuild-wasm-0.25.9.tgz",
-      "integrity": "sha512-Jpv5tCSwQg18aCqCRD3oHIX/prBhXMDapIoG//A+6+dV0e7KQMGFg85ihJ5T1EeMjbZjON3TqFy0VrGAnIHLDA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/escalade": {
@@ -14241,22 +11197,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/event-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
-      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "duplexer": "^0.1.1",
-        "from": "^0.1.7",
-        "map-stream": "0.0.7",
-        "pause-stream": "^0.0.11",
-        "split": "^1.0.1",
-        "stream-combiner": "^0.2.2",
-        "through": "^2.3.8"
-      }
-    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -14293,52 +11233,15 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/execa": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+        "node": ">=12.0.0"
       }
-    },
-    "node_modules/execa/node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/execa/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/exponential-backoff": {
       "version": "3.1.3",
@@ -14407,54 +11310,10 @@
         "express": ">= 4.11"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fancy-log": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-2.0.0.tgz",
-      "integrity": "sha512-9CzxZbACXMUXW13tS0tI8XsGGmxWzO2DmYrGuBJOJ8k8q2K7hwfJA5qHjuPPe8wtsco33YR9wc+Rlr5wYFvhSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-support": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-uri": {
@@ -14472,16 +11331,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
     },
     "node_modules/faye-websocket": {
       "version": "0.11.4",
@@ -14570,13 +11419,6 @@
         "flat": "cli.js"
       }
     },
-    "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
@@ -14597,235 +11439,20 @@
         }
       }
     },
-    "node_modules/fork-ts-checker-webpack-plugin": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-8.0.0.tgz",
-      "integrity": "sha512-mX3qW3idpueT2klaQXBzrIM/pHw+T0B/V9KHEvNrqijTq9NFnMZU6oreVxDYcf33P8a5cW+67PjodNHthGnNVg==",
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.16.7",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "cosmiconfig": "^7.0.1",
-        "deepmerge": "^4.2.2",
-        "fs-extra": "^10.0.0",
-        "memfs": "^3.4.1",
-        "minimatch": "^3.0.4",
-        "node-abort-controller": "^3.0.1",
-        "schema-utils": "^3.1.1",
-        "semver": "^7.3.5",
-        "tapable": "^2.2.1"
+        "is-callable": "^1.2.7"
       },
       "engines": {
-        "node": ">=12.13.0",
-        "yarn": ">=1.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">3.6.0",
-        "webpack": "^5.11.0"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "node": ">= 0.4"
       },
       "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^6.9.1"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/forwarded": {
@@ -14837,20 +11464,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/fraction.js": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "type": "patreon",
-        "url": "https://github.com/sponsors/rawify"
-      }
-    },
     "node_modules/fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
@@ -14858,28 +11471,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/fs-minipass": {
@@ -14893,20 +11484,6 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
-    },
-    "node_modules/fs-monkey": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.1.0.tgz",
-      "integrity": "sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==",
-      "dev": true,
-      "license": "Unlicense"
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -14929,6 +11506,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/gensync": {
@@ -14998,44 +11585,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -15094,38 +11643,6 @@
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "license": "MIT"
     },
-    "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
-    },
-    "node_modules/handlebars/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -15133,6 +11650,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -15173,16 +11703,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "he": "bin/he"
       }
     },
     "node_modules/hono": {
@@ -15257,95 +11777,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/html-entities": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
-      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/mdevils"
-        },
-        {
-          "type": "patreon",
-          "url": "https://patreon.com/mdevils"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/html-escaper": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/html-minifier-terser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
-      "integrity": "sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "clean-css": "^5.2.2",
-        "commander": "^8.3.0",
-        "he": "^1.2.0",
-        "param-case": "^3.0.4",
-        "relateurl": "^0.2.7",
-        "terser": "^5.10.0"
-      },
-      "bin": {
-        "html-minifier-terser": "cli.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/html-minifier-terser/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/html-webpack-plugin": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.4.tgz",
-      "integrity": "sha512-V/PZeWsqhfpE27nKeX9EO2sbR+D17A+tLf6qU+ht66jdUsN0QLKJN27Z+1+gHrVMKgndBahes0PU6rRihDgHTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/html-minifier-terser": "^6.0.0",
-        "html-minifier-terser": "^6.0.2",
-        "lodash": "^4.17.21",
-        "pretty-error": "^4.0.0",
-        "tapable": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/html-webpack-plugin"
-      },
-      "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
-        "webpack": "^5.20.0"
-      },
-      "peerDependenciesMeta": {
-        "@rspack/core": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/htmlparser2": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
@@ -15375,42 +11806,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/http-auth": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/http-auth/-/http-auth-4.1.9.tgz",
-      "integrity": "sha512-kvPYxNGc9EKGTXvOMnTBQw2RZfuiSihK/mLw/a4pbtRueTE45S55Lw/3k5CktIf7Ak0veMKEIteDj4YkNmCzmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "apache-crypt": "^1.1.2",
-        "apache-md5": "^1.0.6",
-        "bcryptjs": "^2.4.3",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/http-auth-connect": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/http-auth-connect/-/http-auth-connect-1.0.6.tgz",
-      "integrity": "sha512-yaO0QSCPqGCjPrl3qEEHjJP+lwZ6gMpXLuCBE06eWwcXomkI5TARtu0kxf9teFuBj6iaV3Ybr15jaWUvbzNzHw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/http-auth/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -15513,16 +11908,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.12.0"
-      }
-    },
     "node_modules/hyperdyperid": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
@@ -15530,48 +11915,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.18"
-      }
-    },
-    "node_modules/i18next": {
-      "version": "25.7.4",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.7.4.tgz",
-      "integrity": "sha512-hRkpEblXXcXSNbw8mBNq9042OEetgyB/ahc/X17uV/khPwzV+uB8RHceHh3qavyrkPJvmXFKXME2Sy1E0KjAfw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4"
-      },
-      "peerDependencies": {
-        "typescript": "^5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/i18next/node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -15685,43 +12028,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-5.0.0.tgz",
-      "integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
     },
     "node_modules/internmap": {
       "version": "2.0.3",
@@ -15750,6 +12061,23 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -15766,6 +12094,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-core-module": {
@@ -15807,17 +12148,24 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">= 0.4"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -15941,17 +12289,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
       "engines": {
-        "node": ">=8"
+        "node": ">= 0.4"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -15993,19 +12344,6 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
-    "node_modules/isbinaryfile": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
-      "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/gjtorikian/"
-      }
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -16046,67 +12384,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-report": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
-      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^4.0.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/istanbul-reports": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
-      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "html-escaper": "^2.0.0",
-        "istanbul-lib-report": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jasmine-core": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.9.0.tgz",
-      "integrity": "sha512-OMUvF1iI6+gSRYOhMrH4QYothVLN9C3EJ6wm4g7zLJlnaTl8zbaPOr0bTw70l7QxkoM7sVFOWo83u9B2Fe2Zng==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/jest-worker": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -16136,16 +12413,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/jiti": {
-      "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jiti": "bin/jiti.js"
-      }
-    },
     "node_modules/jose": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
@@ -16171,6 +12438,16 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.8.0.tgz",
+      "integrity": "sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/jsesc": {
@@ -16224,16 +12501,6 @@
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
     },
-    "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -16243,148 +12510,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/karma": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.4.tgz",
-      "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@colors/colors": "1.5.0",
-        "body-parser": "^1.19.0",
-        "braces": "^3.0.2",
-        "chokidar": "^3.5.1",
-        "connect": "^3.7.0",
-        "di": "^0.0.1",
-        "dom-serialize": "^2.2.1",
-        "glob": "^7.1.7",
-        "graceful-fs": "^4.2.6",
-        "http-proxy": "^1.18.1",
-        "isbinaryfile": "^4.0.8",
-        "lodash": "^4.17.21",
-        "log4js": "^6.4.1",
-        "mime": "^2.5.2",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.5",
-        "qjobs": "^1.2.0",
-        "range-parser": "^1.2.1",
-        "rimraf": "^3.0.2",
-        "socket.io": "^4.7.2",
-        "source-map": "^0.6.1",
-        "tmp": "^0.2.1",
-        "ua-parser-js": "^0.7.30",
-        "yargs": "^16.1.1"
-      },
-      "bin": {
-        "karma": "bin/karma"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/karma-chrome-launcher": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-3.2.0.tgz",
-      "integrity": "sha512-rE9RkUPI7I9mAxByQWkGJFXfFD6lE4gC5nPuZdobf/QdTEJI6EU4yIay/cfU/xV4ZxlM5JiTv7zWYgA64NpS5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "which": "^1.2.1"
-      }
-    },
-    "node_modules/karma-chrome-launcher/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
-    "node_modules/karma-coverage": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-2.2.1.tgz",
-      "integrity": "sha512-yj7hbequkQP2qOSb20GuNSIyE//PgJWHwC2IydLE6XRtsnaflv+/OSGNssPjobYUlhVVagy99TQpqUt3vAUG7A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "istanbul-lib-coverage": "^3.2.0",
-        "istanbul-lib-instrument": "^5.1.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^4.0.1",
-        "istanbul-reports": "^3.0.5",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/karma-coverage/node_modules/istanbul-lib-instrument": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma-coverage/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/karma-jasmine": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-5.1.0.tgz",
-      "integrity": "sha512-i/zQLFrfEpRyQoJF9fsCdTMOF5c2dK7C7OmsuKg2D0YSsuZSfQDiLuaiktbuio6F2wiCsZSnSnieIQ0ant/uzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jasmine-core": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "karma": "^6.0.0"
-      }
-    },
-    "node_modules/karma-jasmine-html-reporter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-2.1.0.tgz",
-      "integrity": "sha512-sPQE1+nlsn6Hwb5t+HHwyy0A1FNCVKuL1192b+XNauMYWThz2kweiBVW1DqloRpVvZIJkIoHVB7XRpK78n1xbQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "jasmine-core": "^4.0.0 || ^5.0.0",
-        "karma": "^6.0.0",
-        "karma-jasmine": "^5.0.0"
-      }
-    },
-    "node_modules/karma-jasmine/node_modules/jasmine-core": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.6.1.tgz",
-      "integrity": "sha512-VYz/BjjmC3klLJlLwA4Kw8ytk0zDSmbbDLNs794VnWmkcCB7I9aAL/D48VNQtmITyPvea2C3jdUMfc3kAoy0PQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/karma-source-map-support": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/karma-source-map-support/-/karma-source-map-support-1.4.0.tgz",
@@ -16392,352 +12517,6 @@
       "license": "MIT",
       "dependencies": {
         "source-map-support": "^0.5.5"
-      }
-    },
-    "node_modules/karma/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/karma/node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "~1.2.0",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
-        "raw-body": "~2.5.3",
-        "type-is": "~1.6.18",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/karma/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/karma/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/karma/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/karma/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/karma/node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/karma/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/karma/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma/node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/karma/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/karma/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/karma/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/karma/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/karma/node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/karma/node_modules/raw-body": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/karma/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/karma/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/karma/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma/node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/karma/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/karma/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/karma/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/kind-of": {
@@ -16757,111 +12536,6 @@
       "dependencies": {
         "picocolors": "^1.1.1",
         "shell-quote": "^1.8.3"
-      }
-    },
-    "node_modules/less": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/less/-/less-4.4.0.tgz",
-      "integrity": "sha512-kdTwsyRuncDfjEs0DlRILWNvxhDG/Zij4YLO4TMJgDLW+8OzpfkdPnRgrsRuY1o+oaxJGWsps5f/RVBgGmmN0w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "copy-anything": "^2.0.1",
-        "parse-node-version": "^1.0.1",
-        "tslib": "^2.3.0"
-      },
-      "bin": {
-        "lessc": "bin/lessc"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "optionalDependencies": {
-        "errno": "^0.1.1",
-        "graceful-fs": "^4.1.2",
-        "image-size": "~0.5.0",
-        "make-dir": "^2.1.0",
-        "mime": "^1.4.1",
-        "needle": "^3.1.0",
-        "source-map": "~0.6.0"
-      }
-    },
-    "node_modules/less-loader": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-12.3.0.tgz",
-      "integrity": "sha512-0M6+uYulvYIWs52y0LqN4+QM9TqWAohYSNTo4htE8Z7Cn3G/qQMEmktfHmyJT23k+20kU9zHH2wrfFXkxNLtVw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
-        "less": "^3.5.0 || ^4.0.0",
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@rspack/core": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/less/node_modules/make-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/less/node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/less/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/less/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/license-webpack-plugin": {
@@ -16887,75 +12561,35 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
-    "node_modules/listr2": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.1.tgz",
-      "integrity": "sha512-SL0JY3DaxylDuo/MecFeiC+7pedM0zia33zl0vcjgwcq1q1FWWF1To9EIauPbl8GbMCU0R2e0uJ8bZunhYKD2g==",
-      "dev": true,
-      "license": "MIT",
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "cli-truncate": "^4.0.0",
-        "colorette": "^2.0.20",
-        "eventemitter3": "^5.0.1",
-        "log-update": "^6.1.0",
-        "rfdc": "^1.4.1",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
       }
     },
-    "node_modules/listr2/node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/listr2/node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "dev": true,
-      "license": "MIT",
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
       }
     },
-    "node_modules/lmdb": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-3.4.2.tgz",
-      "integrity": "sha512-nwVGUfTBUwJKXd6lRV8pFNfnrCC1+l49ESJRM19t/tFb/97QfJEixe5DYRvug5JO7DSFKoKaVy7oGMt5rVqZvg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
+    "node_modules/lit-html": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "msgpackr": "^1.11.2",
-        "node-addon-api": "^6.1.0",
-        "node-gyp-build-optional-packages": "5.2.2",
-        "ordered-binary": "^1.5.3",
-        "weak-lru-cache": "^1.2.2"
-      },
-      "bin": {
-        "download-lmdb-prebuilds": "bin/download-prebuilds.js"
-      },
-      "optionalDependencies": {
-        "@lmdb/lmdb-darwin-arm64": "3.4.2",
-        "@lmdb/lmdb-darwin-x64": "3.4.2",
-        "@lmdb/lmdb-linux-arm": "3.4.2",
-        "@lmdb/lmdb-linux-arm64": "3.4.2",
-        "@lmdb/lmdb-linux-x64": "3.4.2",
-        "@lmdb/lmdb-win32-arm64": "3.4.2",
-        "@lmdb/lmdb-win32-x64": "3.4.2"
+        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/loader-runner": {
@@ -16995,13 +12629,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash-es": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
@@ -17013,36 +12640,6 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
-    },
-    "node_modules/log-symbols": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
-      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.3.0",
-        "is-unicode-supported": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-symbols/node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/log-update": {
       "version": "6.1.0",
@@ -17111,60 +12708,12 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/log4js": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.9.1.tgz",
-      "integrity": "sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "date-format": "^4.0.14",
-        "debug": "^4.3.4",
-        "flatted": "^3.2.7",
-        "rfdc": "^1.3.0",
-        "streamroller": "^3.1.5"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/loglevel": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
-      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/loglevel"
-      }
-    },
-    "node_modules/loglevel-plugin-prefix": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
-      "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -17175,26 +12724,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/lunr": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/macos-release": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.5.1.tgz",
-      "integrity": "sha512-DXqXhEM7gW59OjZO8NIjBCz9AQ1BEMrfiOAl4AYByHCtVHRF4KoGNO8mqQeM8lRCtQe/UnJ4imO/d2HdkKsd+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -17203,22 +12732,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
-      }
-    },
-    "node_modules/make-dir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -17253,39 +12766,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/map-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/marked": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-7.0.3.tgz",
-      "integrity": "sha512-ev2uM40p0zQ/GbvqotfKcSWEa59fJwluGZj5dcaUOwDRrB1F3dncdXy8NWUApk4fi8atU3kTBOwjyjZ0ud0dxw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 16"
-      }
-    },
-    "node_modules/matchit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/matchit/-/matchit-1.1.0.tgz",
-      "integrity": "sha512-+nGYoOlfHmxe5BW5tE0EMJppXEwdSf8uBA1GTZC7Q77kbT35+VKLYJMzVNWCHSsga1ps1tPYFtFyvxvKzWVmMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@arr/every": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -17302,19 +12782,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/memfs": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
-      "integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
-      "dev": true,
-      "license": "Unlicense",
-      "dependencies": {
-        "fs-monkey": "^1.0.4"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/merge-descriptors": {
@@ -17334,16 +12801,6 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "license": "MIT"
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -17379,19 +12836,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -17413,16 +12857,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -17435,65 +12869,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/mini-css-extract-plugin": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.4.tgz",
-      "integrity": "sha512-ZWYT7ln73Hptxqxk2DxPU9MmapXRhxkJD6tkSR04dnQxm8BGu2hzgKLugK5yySD97u/8yy7Ma7E76k9ZdvtjkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "schema-utils": "^4.0.0",
-        "tapable": "^2.2.1"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      }
-    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "license": "ISC"
-    },
-    "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/minipass": {
       "version": "7.1.3",
@@ -17634,66 +13014,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/morgan": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
-      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "basic-auth": "~2.0.1",
-        "debug": "2.6.9",
-        "depd": "~2.0.0",
-        "on-finished": "~2.3.0",
-        "on-headers": "~1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/morgan/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/morgan/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/morgan/node_modules/on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -17826,50 +13146,12 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
     },
-    "node_modules/neotraverse": {
-      "version": "0.6.18",
-      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
-      "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/node-abort-controller": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/node-addon-api": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
       "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
-      "dev": true,
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
-      }
     },
     "node_modules/node-gyp": {
       "version": "12.2.0",
@@ -17968,16 +13250,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -18087,19 +13359,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -18184,82 +13443,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/open": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "default-browser": "^5.2.1",
-        "define-lazy-prop": "^3.0.0",
-        "is-inside-container": "^1.0.0",
-        "wsl-utils": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/opencollective-postinstall": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
-      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "opencollective-postinstall": "index.js"
-      }
-    },
-    "node_modules/ora": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
-      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.3.0",
-        "cli-cursor": "^5.0.0",
-        "cli-spinners": "^2.9.2",
-        "is-interactive": "^2.0.0",
-        "is-unicode-supported": "^2.0.0",
-        "log-symbols": "^6.0.0",
-        "stdin-discarder": "^0.2.2",
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ordered-binary": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.6.0.tgz",
       "integrity": "sha512-IQh2aMfMIDbPjI/8a3Edr+PiOpcsB7yo8NdW7aHWVaoR/pcDldunMvnnwbk/auPGqmKeAdxtZl7MHX/QmPwhvQ==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/os-name": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/os-name/-/os-name-4.0.1.tgz",
-      "integrity": "sha512-xl9MAoU97MH1Xt5K9ERft2YfCAoaO6msy1OBA0ozxEC0x0TmIoE6K3QvgJMMZA9yKGLmHXNY/YZoDbiGDj4zYw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "macos-release": "^2.5.0",
-        "windows-release": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -18327,59 +13516,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/pacote": {
-      "version": "21.0.4",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.0.4.tgz",
-      "integrity": "sha512-RplP/pDW0NNNDh3pnaoIWYPvNenS7UqMbXyvMqJczosiFWTeGGwJC2NQBLqKf4rGLFfwCOnntw1aEp9Jiqm1MA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^7.0.0",
-        "@npmcli/installed-package-contents": "^4.0.0",
-        "@npmcli/package-json": "^7.0.0",
-        "@npmcli/promise-spawn": "^9.0.0",
-        "@npmcli/run-script": "^10.0.0",
-        "cacache": "^20.0.0",
-        "fs-minipass": "^3.0.0",
-        "minipass": "^7.0.2",
-        "npm-package-arg": "^13.0.0",
-        "npm-packlist": "^10.0.1",
-        "npm-pick-manifest": "^11.0.1",
-        "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^6.0.0",
-        "promise-retry": "^2.0.1",
-        "sigstore": "^4.0.0",
-        "ssri": "^13.0.0",
-        "tar": "^7.4.3"
-      },
-      "bin": {
-        "pacote": "bin/index.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/pacote/node_modules/proc-log": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/parent-module": {
@@ -18465,85 +13601,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
-      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domhandler": "^5.0.3",
-        "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-parser-stream": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
-      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-parser-stream/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/parse5-parser-stream/node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/parse5-sax-parser": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5-sax-parser/-/parse5-sax-parser-8.0.0.tgz",
@@ -18577,24 +13634,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -18602,16 +13641,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -18664,15 +13693,12 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
+      "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "2.0.1",
@@ -18682,19 +13708,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
-      }
-    },
-    "node_modules/pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
-      "dev": true,
-      "license": [
-        "MIT",
-        "Apache2"
-      ],
-      "dependencies": {
-        "through": "~2.3"
       }
     },
     "node_modules/picocolors": {
@@ -18725,19 +13738,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/piscina": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.1.3.tgz",
-      "integrity": "sha512-0u3N7H4+hbr40KjuVn2uNhOcthu/9usKhnw5vT3J7ply79v3D3M8naI00el9Klcy16x557VsEkkUQaHCWFXC/g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.x"
-      },
-      "optionalDependencies": {
-        "@napi-rs/nice": "^1.0.4"
-      }
-    },
     "node_modules/pkce-challenge": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
@@ -18764,15 +13764,14 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/polka": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/polka/-/polka-0.5.2.tgz",
-      "integrity": "sha512-FVg3vDmCqP80tOrs+OeNlgXYmFppTXdjD5E7I4ET1NjvtNmQrb1/mJibybKkb/d4NA7YWAr1ojxuhpL3FHqdlw==",
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@polka/url": "^0.5.0",
-        "trouter": "^2.0.1"
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -18801,38 +13800,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postcss-loader": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-8.1.1.tgz",
-      "integrity": "sha512-0IeqyAsG6tYiDRCYKQJLAmgQr47DX6N7sFSWvQxt6AcupX8DIdmykuk/o/tx0Lze3ErGHJEp5OSRxrelC6+NdQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cosmiconfig": "^9.0.0",
-        "jiti": "^1.20.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
-        "postcss": "^7.0.0 || ^8.0.1",
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@rspack/core": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
       }
     },
     "node_modules/postcss-media-query-parser": {
@@ -18931,27 +13898,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/pretty-error": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
-      "integrity": "sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.20",
-        "renderkid": "^3.0.0"
-      }
-    },
-    "node_modules/prismjs": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
-      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/proc-log": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
@@ -18959,6 +13905,16 @@
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -18993,40 +13949,12 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-middleware": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.15.0.tgz",
-      "integrity": "sha512-EGCG8SeoIRVMhsqHQUdDigB2i7qU7fCsWASwn54+nPutYO8n4q6EiwMzyfWlC+dzRFExP+kvcnDFdBDHoZBU7Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/pvtsutils": {
       "version": "1.3.6",
@@ -19046,16 +13974,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/qjobs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.2.0.tgz",
-      "integrity": "sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.9"
-      }
-    },
     "node_modules/qs": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
@@ -19070,27 +13988,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -19194,20 +14091,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
@@ -19273,169 +14156,6 @@
         "regjsparser": "bin/parser"
       }
     },
-    "node_modules/relateurl": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/renderkid": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
-      "integrity": "sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-select": "^4.1.3",
-        "dom-converter": "^0.2.0",
-        "htmlparser2": "^6.1.0",
-        "lodash": "^4.17.21",
-        "strip-ansi": "^6.0.1"
-      }
-    },
-    "node_modules/renderkid/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/renderkid/node_modules/css-select": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.0.1",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/renderkid/node_modules/css-what": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/renderkid/node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/renderkid/node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/renderkid/node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/renderkid/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/renderkid/node_modules/htmlparser2": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-      "dev": true,
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
-      }
-    },
-    "node_modules/renderkid/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -19450,27 +14170,6 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "license": "MIT"
-    },
-    "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.16.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -19545,39 +14244,11 @@
         "node": ">= 4"
       }
     },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/robust-predicates": {
       "version": "3.0.2",
@@ -19688,30 +14359,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
     "node_modules/rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
@@ -19792,47 +14439,6 @@
         "@parcel/watcher": "^2.4.1"
       }
     },
-    "node_modules/sass-loader": {
-      "version": "16.0.5",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.5.tgz",
-      "integrity": "sha512-oL+CMBXrj6BZ/zOq4os+UECPL+bWqt6OAC6DWS8Ln8GZRcMDjlJ4JC3FBDuHJdYaFWIdKNIBYmtZtK2MaMkNIw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "neo-async": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
-        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
-        "sass": "^1.3.0",
-        "sass-embedded": "*",
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@rspack/core": {
-          "optional": true
-        },
-        "node-sass": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/sax": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
@@ -19888,20 +14494,6 @@
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
       "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
       "license": "MIT"
-    },
-    "node_modules/selfsigned": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
-      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node-forge": "^1.3.0",
-        "node-forge": "^1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -20086,6 +14678,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -20209,6 +14819,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -20238,45 +14855,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/sirv": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
-      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@polka/url": "^1.0.0-next.24",
-        "mrmime": "^2.0.0",
-        "totalist": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/sirv/node_modules/@polka/url": {
-      "version": "1.0.0-next.29",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
-      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/slice-ansi": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.0.0",
-        "is-fullwidth-code-point": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -20285,133 +14863,6 @@
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socket.io": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
-      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "~1.3.4",
-        "base64id": "~2.0.0",
-        "cors": "~2.8.5",
-        "debug": "~4.3.2",
-        "engine.io": "~6.6.0",
-        "socket.io-adapter": "~2.5.2",
-        "socket.io-parser": "~4.2.4"
-      },
-      "engines": {
-        "node": ">=10.2.0"
-      }
-    },
-    "node_modules/socket.io-adapter": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
-      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "~4.3.4",
-        "ws": "~8.17.1"
-      }
-    },
-    "node_modules/socket.io-adapter/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/socket.io-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.4.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/socket.io/node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/socket.io/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/socket.io/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/socket.io/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/socket.io/node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/sockjs": {
@@ -20583,19 +15034,6 @@
         "wbuf": "^1.7.3"
       }
     },
-    "node_modules/split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "through": "2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/ssri": {
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
@@ -20608,6 +15046,13 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -20617,40 +15062,25 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/stdin-discarder": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+      "license": "MIT"
     },
     "node_modules/storybook": {
-      "version": "9.1.20",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.20.tgz",
-      "integrity": "sha512-6rME2tww6PFhm96iG2Xx44yzwLDWBiDWy+kJ2ub6x90werSTOiuo+tZJ94BgCfFutR0tEfLRIq59s+Zg6YyChA==",
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.6.18.tgz",
+      "integrity": "sha512-p8seiSI6FiVY6P3V0pG+5v7c8pDMehMAFRWEhG5XqIBSQszzOjDnW2rNvm3odoLKfo3V3P6Cs6Hv9ILzymULyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/user-event": "^14.6.1",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "better-opn": "^3.0.2",
-        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0",
-        "esbuild-register": "^3.5.0",
-        "recast": "^0.23.5",
-        "semver": "^7.6.2",
-        "ws": "^8.18.0"
+        "@storybook/core": "8.6.18"
       },
       "bin": {
+        "getstorybook": "bin/index.cjs",
+        "sb": "bin/index.cjs",
         "storybook": "bin/index.cjs"
       },
       "funding": {
@@ -20664,54 +15094,6 @@
         "prettier": {
           "optional": true
         }
-      }
-    },
-    "node_modules/storybook/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/stream-combiner": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "duplexer": "~0.1.1",
-        "through": "~2.3.4"
-      }
-    },
-    "node_modules/streamroller": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
-      "integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "date-format": "^4.0.14",
-        "debug": "^4.3.4",
-        "fs-extra": "^8.1.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/string_decoder": {
@@ -20755,68 +15137,25 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "min-indent": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/style-loader": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.4.tgz",
-      "integrity": "sha512-0WqXzrsMTyb8yjZJHDqwmnwRJvhALK9LfRtRc6B4UTWe8AijYLZYZ9thuJTZc2VfQWINADW/j+LiJnfy2RoC1w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.13.0"
+        "js-tokens": "^9.0.1"
       },
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
+        "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+      "license": "MIT"
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
@@ -20828,24 +15167,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/svg-pan-zoom": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/svg-pan-zoom/-/svg-pan-zoom-3.6.2.tgz",
-      "integrity": "sha512-JwnvRWfVKw/Xzfe6jriFyfey/lWJLq4bUh2jwoR5ChWQuQoOH8FEh1l/bEp46iHHKHEJWIyFJETbazraxNWECg==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/tablesort": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/tablesort/-/tablesort-5.7.0.tgz",
-      "integrity": "sha512-irnN1HPD08466v6DHKR1+gqZ2be2+QZBDIGTM1DFGoWywY+d38bFtfsuUqBbMGkqaMyYE1uPxE7p0AM5cmbRSA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 22",
-        "npm": ">= 10"
       }
     },
     "node_modules/tapable": {
@@ -20885,13 +15206,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/telejson": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/telejson/-/telejson-8.0.0.tgz",
-      "integrity": "sha512-8mCI1dHX80nchOkIEgvyWlGLgeh/SxO7JZPOud0DxvfFdI6MgwxRL8ff7rVdj6436uHhpWaxLQjU74Jb2I0u9g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/terser": {
       "version": "5.43.1",
@@ -20966,13 +15280,6 @@
         "tslib": "^2"
       }
     },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -20983,6 +15290,20 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -21000,6 +15321,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/tinyrainbow": {
@@ -21022,16 +15353,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -21051,16 +15372,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/totalist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
-      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/tree-dump": {
@@ -21088,19 +15399,6 @@
         "tree-kill": "cli.js"
       }
     },
-    "node_modules/trouter": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/trouter/-/trouter-2.0.1.tgz",
-      "integrity": "sha512-kr8SKKw94OI+xTGOkfsvwZQ8mWoikZDd2n8XZHjJVZUARZT+4/VV6cacRS6CLsH9bNm+HFIPU1Zx4CnNnb4qlQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "matchit": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ts-dedent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
@@ -21109,81 +15407,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.10"
-      }
-    },
-    "node_modules/ts-morph": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-27.0.2.tgz",
-      "integrity": "sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ts-morph/common": "~0.28.1",
-        "code-block-writer": "^13.0.3"
-      }
-    },
-    "node_modules/tsconfig-paths": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
-      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json5": "^2.2.2",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tsconfig-paths-webpack-plugin": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz",
-      "integrity": "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "enhanced-resolve": "^5.7.0",
-        "tapable": "^2.2.1",
-        "tsconfig-paths": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/tsconfig-paths-webpack-plugin/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/tsconfig-paths-webpack-plugin/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/tslib": {
@@ -21245,9 +15468,10 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -21255,47 +15479,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/ua-parser-js": {
-      "version": "0.7.41",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.41.tgz",
-      "integrity": "sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "ua-parser-js": "script/cli.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/uglify-js": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
-      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/undici": {
@@ -21353,23 +15536,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/unix-crypt-td-js": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/unix-crypt-td-js/-/unix-crypt-td-js-1.1.4.tgz",
-      "integrity": "sha512-8rMeVYWSIyccIJscb9NdCfZKSRBKYTeVnwmiRYT2ulE3qd1RaDQ0xQDP+rI3ccIWbhu/zuo5cgN8z73belNZgw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -21423,37 +15589,24 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uri-js/node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=6"
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
-    },
-    "node_modules/utila": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
-      "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -21483,44 +15636,25 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/vis-network": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-10.0.2.tgz",
-      "integrity": "sha512-qPl8GLYBeHEFqiTqp4VBbYQIJ2EA8KLr7TstA2E8nJxfEHaKCU81hQLz7hhq11NUpHbMaRzBjW5uZpVKJ45/wA==",
-      "dev": true,
-      "license": "(Apache-2.0 OR MIT)",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/visjs"
-      },
-      "peerDependencies": {
-        "@egjs/hammerjs": "^2.0.0",
-        "component-emitter": "^1.3.0 || ^2.0.0",
-        "keycharm": "^0.2.0 || ^0.3.0 || ^0.4.0",
-        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0",
-        "vis-data": ">=8.0.0",
-        "vis-util": ">=6.0.0"
-      }
-    },
     "node_modules/vite": {
-      "version": "7.1.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.11.tgz",
-      "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -21529,14 +15663,14 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
         "jiti": ">=1.21.0",
-        "less": "^4.0.0",
+        "less": "*",
         "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"
@@ -21577,6 +15711,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite/node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -21594,28 +15751,77 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/void-elements": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
-      "integrity": "sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/watchpack": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
-      "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.1.2"
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
       }
     },
     "node_modules/wbuf": {
@@ -21633,685 +15839,6 @@
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/webpack": {
-      "version": "5.105.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
-      "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
-        "@types/estree": "^1.0.8",
-        "@types/json-schema": "^7.0.15",
-        "@webassemblyjs/ast": "^1.14.1",
-        "@webassemblyjs/wasm-edit": "^1.14.1",
-        "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.15.0",
-        "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.28.1",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.19.0",
-        "es-module-lexer": "^2.0.0",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.3.1",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.3",
-        "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.3.16",
-        "watchpack": "^2.5.1",
-        "webpack-sources": "^3.3.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-dev-middleware": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.2.tgz",
-      "integrity": "sha512-xOO8n6eggxnwYpy1NlzUKpvrjfJTvae5/D6WOK0S2LSo7vjmo5gCM1DbLUmFqrMTJP+W/0YZNctm7jasWvLuBA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "colorette": "^2.0.10",
-        "memfs": "^4.6.0",
-        "mime-types": "^2.1.31",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "schema-utils": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-dev-middleware/node_modules/memfs": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.1.tgz",
-      "integrity": "sha512-WvzrWPwMQT+PtbX2Et64R4qXKK0fj/8pO85MrUCzymX3twwCiJCdvntW3HdhG1teLJcHDDLIKx5+c3HckWYZtQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jsonjoy.com/fs-core": "4.57.1",
-        "@jsonjoy.com/fs-fsa": "4.57.1",
-        "@jsonjoy.com/fs-node": "4.57.1",
-        "@jsonjoy.com/fs-node-builtins": "4.57.1",
-        "@jsonjoy.com/fs-node-to-fsa": "4.57.1",
-        "@jsonjoy.com/fs-node-utils": "4.57.1",
-        "@jsonjoy.com/fs-print": "4.57.1",
-        "@jsonjoy.com/fs-snapshot": "4.57.1",
-        "@jsonjoy.com/json-pack": "^1.11.0",
-        "@jsonjoy.com/util": "^1.9.0",
-        "glob-to-regex.js": "^1.0.1",
-        "thingies": "^2.5.0",
-        "tree-dump": "^1.0.3",
-        "tslib": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/webpack-dev-middleware/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpack-dev-middleware/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpack-dev-server": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
-      "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/bonjour": "^3.5.13",
-        "@types/connect-history-api-fallback": "^1.5.4",
-        "@types/express": "^4.17.21",
-        "@types/express-serve-static-core": "^4.17.21",
-        "@types/serve-index": "^1.9.4",
-        "@types/serve-static": "^1.15.5",
-        "@types/sockjs": "^0.3.36",
-        "@types/ws": "^8.5.10",
-        "ansi-html-community": "^0.0.8",
-        "bonjour-service": "^1.2.1",
-        "chokidar": "^3.6.0",
-        "colorette": "^2.0.10",
-        "compression": "^1.7.4",
-        "connect-history-api-fallback": "^2.0.0",
-        "express": "^4.21.2",
-        "graceful-fs": "^4.2.6",
-        "http-proxy-middleware": "^2.0.9",
-        "ipaddr.js": "^2.1.0",
-        "launch-editor": "^2.6.1",
-        "open": "^10.0.3",
-        "p-retry": "^6.2.0",
-        "schema-utils": "^4.2.0",
-        "selfsigned": "^2.4.1",
-        "serve-index": "^1.9.1",
-        "sockjs": "^0.3.24",
-        "spdy": "^4.0.2",
-        "webpack-dev-middleware": "^7.4.2",
-        "ws": "^8.18.0"
-      },
-      "bin": {
-        "webpack-dev-server": "bin/webpack-dev-server.js"
-      },
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "webpack": {
-          "optional": true
-        },
-        "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "~1.2.0",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
-        "raw-body": "~2.5.3",
-        "type-is": "~1.6.18",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/cookie-signature": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/webpack-dev-server/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/debug/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/webpack-dev-server/node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
-        "content-disposition": "~0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "~0.7.1",
-        "cookie-signature": "~1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.3.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "~0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "~0.19.0",
-        "serve-static": "~1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "~2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/finalhandler": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
-      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "~2.0.2",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-proxy": "^1.17.8",
-        "http-proxy": "^1.18.1",
-        "is-glob": "^4.0.1",
-        "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "@types/express": "^4.17.13"
-      },
-      "peerDependenciesMeta": {
-        "@types/express": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/ipaddr.js": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
-      "integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/webpack-dev-server/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/raw-body": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/send": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
-      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.1",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "~2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "~2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/serve-static": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
-      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "~0.19.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-hot-middleware": {
-      "version": "2.26.1",
-      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.26.1.tgz",
-      "integrity": "sha512-khZGfAeJx6I8K9zKohEWWYN6KDlVw2DHownoe+6Vtwj1LP9WFgegXnVMSkZ/dBEBtXFwrkkydsaPFlB7f8wU2A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-html-community": "0.0.8",
-        "html-entities": "^2.1.0",
-        "strip-ansi": "^6.0.0"
-      }
-    },
-    "node_modules/webpack-hot-middleware/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/webpack-hot-middleware/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/webpack-merge": {
       "version": "6.0.1",
@@ -22364,57 +15891,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/webpack/node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/webpack/node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/webpack/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpack/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpack/node_modules/watchpack": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
-      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
@@ -22438,42 +15914,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -22489,33 +15929,49 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wildcard": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
       "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
-      "license": "MIT"
-    },
-    "node_modules/windows-release": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-4.0.0.tgz",
-      "integrity": "sha512-OxmV4wzDKB1x7AZaZgXMVsdJ1qER1ed83ZrTYd5Bwq2HfJVg3DJS8nqlAG4sMoJ7mu8cuRmLEYyU13BKwctRAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {
@@ -22623,22 +16079,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/wsl-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
-      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-wsl": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fontsource-variable/roboto-mono": "^5.2.8",
         "@fontsource-variable/source-code-pro": "^5.2.7",
         "@fontsource/atkinson-hyperlegible": "^5.2.8",
-        "@pawn002/okca": "^1.0.1",
+        "@pawn002/okca": "^2.0.2",
         "apca-w3": "^0.1.9",
         "bridge-pca": "^0.1.6",
         "colorjs.io": "^0.5.2",
@@ -4088,19 +4088,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@candor-design/tokens/node_modules/watchpack": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
-      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
-      "license": "MIT",
-      "dependencies": {
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/@candor-design/tokens/node_modules/webpack": {
       "version": "5.105.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
@@ -4720,7 +4707,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4737,7 +4723,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4754,7 +4739,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4771,7 +4755,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4788,7 +4771,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4805,7 +4787,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4822,7 +4803,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4839,7 +4819,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4856,7 +4835,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4873,7 +4851,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4890,7 +4867,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4907,7 +4883,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4924,7 +4899,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4941,7 +4915,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4958,7 +4931,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4975,7 +4947,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4992,7 +4963,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5009,7 +4979,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5026,7 +4995,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5043,7 +5011,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5060,7 +5027,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5077,7 +5043,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5094,7 +5059,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5111,7 +5075,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5128,7 +5091,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5145,7 +5107,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6813,7 +6774,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6834,7 +6794,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6855,7 +6814,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6876,7 +6834,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6897,7 +6854,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6918,7 +6874,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6939,7 +6894,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6960,7 +6914,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6981,7 +6934,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7002,7 +6954,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7023,7 +6974,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7044,7 +6994,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7065,7 +7014,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7100,9 +7048,9 @@
       "optional": true
     },
     "node_modules/@pawn002/okca": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@pawn002/okca/-/okca-1.0.1.tgz",
-      "integrity": "sha512-ZmYpGbu4gFdC5SOPVQOaDRlCfF8x2csFCMJeuimHgkhLq12owt9ga73aJcaWENkeWHY34FHdnRdN8eX8lzDZUg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@pawn002/okca/-/okca-2.0.2.tgz",
+      "integrity": "sha512-PkJtZZvsp4E+MCkd+YnWHlFEYjXg94oq7r5Ou6A5nawzNICLgHOLgaQa1vsQE6isZ844KH67U9U210ILXbJlZA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -8237,7 +8185,7 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*",
@@ -8551,7 +8499,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/eslint": {
@@ -8682,6 +8630,17 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
     },
     "node_modules/@types/retry": {
       "version": "0.12.2",
@@ -9054,9 +9013,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -9282,7 +9241,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9848,7 +9807,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -10262,6 +10221,14 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/d3": {
       "version": "7.9.0",
@@ -11046,7 +11013,7 @@
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
       "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -11173,7 +11140,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -11237,7 +11204,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
       "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
@@ -13697,7 +13664,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/pathval": {
@@ -14054,7 +14021,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -14422,7 +14389,7 @@
       "version": "1.90.0",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.90.0.tgz",
       "integrity": "sha512-9GUyuksjw70uNpb1MTYWsH9MQHOHY6kwfnkafC24+7aOMZn9+rVMBxRbLvw756mrBFbIsFg6Xw9IkR2Fnn3k+Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -14823,7 +14790,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/signal-exit": {
@@ -15050,7 +15017,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/statuses": {
@@ -15297,7 +15264,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
@@ -15471,7 +15438,7 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -15640,7 +15607,7 @@
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -15738,7 +15705,7 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -15824,6 +15791,19 @@
         }
       }
     },
+    "node_modules/watchpack": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+      "license": "MIT",
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/wbuf": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
@@ -15840,6 +15820,54 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/webpack": {
+      "version": "5.106.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
+      "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.8",
+        "@types/json-schema": "^7.0.15",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.16.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.28.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.20.0",
+        "es-module-lexer": "^2.0.0",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "loader-runner": "^4.3.1",
+        "mime-db": "^1.54.0",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.3.17",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.3.4"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webpack-merge": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
@@ -15855,9 +15883,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-      "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.1.tgz",
+      "integrity": "sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==",
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
@@ -15890,6 +15918,13 @@
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/webpack/node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
@@ -15955,7 +15990,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "color-pair-quick-iterator",
   "version": "1.0.0",
+  "type": "module",
   "scripts": {
-    "ng": "ng",
-    "start": "ng serve",
-    "build": "ng build",
-    "build:gh-pages": "ng build --base-href=/color-pair-quick-iterator/",
-    "deploy:gh-pages": "npm run build:gh-pages && rm -rf docs/* && cp -r dist/color-pair-quick-iterator/browser/* docs/ && git add docs/ && git commit -m \"build: update GitHub Pages deployment with latest changes\" && git push",
-    "watch": "ng build --watch --configuration development",
-    "test": "ng test",
-    "storybook": "ng run color-pair-quick-iterator:storybook",
-    "build-storybook": "ng run color-pair-quick-iterator:build-storybook"
+    "start": "vite",
+    "build": "vite build",
+    "build:gh-pages": "vite build --base=/color-pair-quick-iterator/",
+    "deploy:gh-pages": "npm run build:gh-pages && rm -rf docs/* && cp -r dist/* docs/ && git add docs/ && git commit -m \"build: update GitHub Pages deployment with latest changes\" && git push",
+    "preview": "vite preview",
+    "test": "vitest",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
   },
   "prettier": {
     "printWidth": 100,
@@ -19,20 +19,13 @@
       {
         "files": "*.html",
         "options": {
-          "parser": "angular"
+          "parser": "html"
         }
       }
     ]
   },
   "private": true,
   "dependencies": {
-    "@angular/common": "^20.3.0",
-    "@angular/compiler": "^20.3.0",
-    "@angular/core": "^20.3.0",
-    "@angular/forms": "^20.3.0",
-    "@angular/platform-browser": "^20.3.0",
-    "@angular/platform-browser-dynamic": "^20.3.19",
-    "@angular/router": "^20.3.0",
     "@candor-design/tokens": "^1.0.1",
     "@fontsource-variable/roboto-flex": "^5.2.8",
     "@fontsource-variable/roboto-mono": "^5.2.8",
@@ -43,29 +36,19 @@
     "bridge-pca": "^0.1.6",
     "colorjs.io": "^0.5.2",
     "d3": "^7.9.0",
-    "lodash-es": "^4.17.21",
-    "rxjs": "~7.8.0",
-    "tslib": "^2.3.0",
-    "zone.js": "^0.15.1"
+    "lit": "^3.2.0",
+    "lodash-es": "^4.17.21"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^20.3.0",
-    "@angular/build": "^20.3.4",
-    "@angular/cli": "^20.3.4",
-    "@angular/compiler-cli": "^20.3.0",
-    "@compodoc/compodoc": "^1.1.31",
-    "@storybook/addon-docs": "^9.1.10",
-    "@storybook/angular": "^9.1.10",
+    "@storybook/addon-docs": "^8.6.12",
+    "@storybook/web-components": "^8.6.12",
+    "@storybook/web-components-vite": "^8.6.12",
     "@types/d3": "^7.4.3",
-    "@types/jasmine": "~5.1.0",
     "@types/lodash-es": "^4.17.12",
-    "jasmine-core": "~5.9.0",
-    "karma": "~6.4.0",
-    "karma-chrome-launcher": "~3.2.0",
-    "karma-coverage": "~2.2.0",
-    "karma-jasmine": "~5.1.0",
-    "karma-jasmine-html-reporter": "~2.1.0",
-    "storybook": "^9.1.10",
-    "typescript": "~5.9.2"
+    "sass": "^1.89.0",
+    "storybook": "^8.6.12",
+    "typescript": "~5.7.3",
+    "vite": "^6.3.5",
+    "vitest": "^3.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@fontsource-variable/roboto-mono": "^5.2.8",
     "@fontsource-variable/source-code-pro": "^5.2.7",
     "@fontsource/atkinson-hyperlegible": "^5.2.8",
-    "@pawn002/okca": "^1.0.1",
+    "@pawn002/okca": "^2.0.2",
     "apca-w3": "^0.1.9",
     "bridge-pca": "^0.1.6",
     "colorjs.io": "^0.5.2",

--- a/src/app/_candor/accordion/accordion-item.component.scss
+++ b/src/app/_candor/accordion/accordion-item.component.scss
@@ -1,4 +1,4 @@
-:host {
+candor-accordion-item {
   display: block;
 
   &:last-child {

--- a/src/app/_candor/accordion/accordion-item.ts
+++ b/src/app/_candor/accordion/accordion-item.ts
@@ -1,0 +1,49 @@
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import './accordion-item.component.scss';
+
+@customElement('candor-accordion-item')
+export class CandorAccordionItem extends LitElement {
+  override createRenderRoot(): this {
+    return this;
+  }
+
+  @property() override title = '';
+  @property({ type: Boolean }) open = false;
+  @property() variant: 'default' | 'subtle' | 'quiet' = 'default';
+
+  override render() {
+    return html`
+      <details class="accordion-item" ?open=${this.open}>
+        <summary class="accordion-item__summary">
+          <span class=${'accordion-item__title accordion-item__title--' + this.variant}>
+            ${this.title}
+          </span>
+          <svg
+            class="accordion-item__chevron"
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </summary>
+        <div class="accordion-item__panel">
+          <div class="accordion-item__content">
+            <slot></slot>
+          </div>
+        </div>
+      </details>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'candor-accordion-item': CandorAccordionItem;
+  }
+}

--- a/src/app/_candor/button/button.ts
+++ b/src/app/_candor/button/button.ts
@@ -1,0 +1,45 @@
+import { LitElement, html, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import './button.component.scss';
+
+type ButtonVariant = 'primary' | 'secondary' | 'tertiary' | 'ghost' | 'destructive';
+type ButtonSize = 'small' | 'medium' | 'large' | 'icon';
+
+@customElement('candor-button')
+export class CandorButton extends LitElement {
+  override createRenderRoot(): this {
+    return this;
+  }
+
+  @property() variant: ButtonVariant = 'primary';
+  @property() size: ButtonSize = 'medium';
+  @property({ type: Boolean }) disabled = false;
+  @property() type: 'button' | 'submit' | 'reset' = 'button';
+  @property({ attribute: 'aria-label' }) override ariaLabel: string | null = null;
+
+  private onClick(event: Event) {
+    if (!this.disabled) {
+      this.dispatchEvent(new CustomEvent('clicked', { detail: event, bubbles: true, composed: true }));
+    }
+  }
+
+  override render() {
+    return html`
+      <button
+        type=${this.type}
+        ?disabled=${this.disabled}
+        aria-label=${this.ariaLabel ?? nothing}
+        class=${'button button--' + this.variant + ' button--' + this.size}
+        @click=${this.onClick}
+      >
+        <slot></slot>
+      </button>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'candor-button': CandorButton;
+  }
+}

--- a/src/app/_candor/card/card.component.scss
+++ b/src/app/_candor/card/card.component.scss
@@ -1,4 +1,4 @@
-:host {
+candor-card {
   display: block;
 }
 

--- a/src/app/_candor/card/card.ts
+++ b/src/app/_candor/card/card.ts
@@ -1,0 +1,38 @@
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import './card.component.scss';
+
+type CardVariant = 'default' | 'elevated' | 'outlined';
+type CardPadding = 'none' | 'sm' | 'md' | 'lg';
+
+@customElement('candor-card')
+export class CandorCard extends LitElement {
+  override createRenderRoot(): this {
+    return this;
+  }
+
+  @property() variant: CardVariant = 'default';
+  @property() padding: CardPadding = 'md';
+
+  override render() {
+    return html`
+      <div class=${'card card--' + this.variant + ' card--padding-' + this.padding}>
+        <div class="card__header">
+          <slot name="header"></slot>
+        </div>
+        <div class="card__body">
+          <slot></slot>
+        </div>
+        <div class="card__footer">
+          <slot name="footer"></slot>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'candor-card': CandorCard;
+  }
+}

--- a/src/app/_candor/form/checkbox/checkbox.ts
+++ b/src/app/_candor/form/checkbox/checkbox.ts
@@ -1,0 +1,59 @@
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import './checkbox.component.scss';
+
+@customElement('candor-checkbox')
+export class CandorCheckbox extends LitElement {
+  override createRenderRoot(): this {
+    return this;
+  }
+
+  @property() label?: string;
+  @property({ attribute: 'input-id' }) inputId?: string;
+  @property({ type: Boolean }) required = false;
+  @property() name?: string;
+  @property({ type: Boolean }) checked = false;
+  @property({ type: Boolean }) disabled = false;
+
+  private _generatedId = `checkbox-${Math.random().toString(36).substr(2, 9)}`;
+
+  get checkboxId() {
+    return this.inputId || this.getAttribute('id') || this._generatedId;
+  }
+
+  private onCheckboxChange(event: Event) {
+    const target = event.target as HTMLInputElement;
+    this.checked = target.checked;
+    this.dispatchEvent(
+      new CustomEvent('changed', { detail: this.checked, bubbles: true, composed: true }),
+    );
+  }
+
+  override render() {
+    return html`
+      <label
+        for=${this.checkboxId}
+        class=${'checkbox-wrapper' + (this.disabled ? ' checkbox-wrapper--disabled' : '')}
+      >
+        <input
+          type="checkbox"
+          id=${this.checkboxId}
+          name=${this.name ?? ''}
+          ?checked=${this.checked}
+          ?disabled=${this.disabled}
+          ?required=${this.required}
+          class="checkbox-input"
+          @change=${this.onCheckboxChange}
+        />
+        <span class="checkbox-box"></span>
+        <span class="checkbox-label">${this.label}</span>
+      </label>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'candor-checkbox': CandorCheckbox;
+  }
+}

--- a/src/app/_candor/form/radio/radio.ts
+++ b/src/app/_candor/form/radio/radio.ts
@@ -1,0 +1,60 @@
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import './radio.component.scss';
+
+@customElement('candor-radio')
+export class CandorRadio extends LitElement {
+  override createRenderRoot(): this {
+    return this;
+  }
+
+  @property() label?: string;
+  @property() value?: string;
+  @property() name?: string;
+  @property({ attribute: 'input-id' }) inputId?: string;
+  @property({ type: Boolean }) checked = false;
+  @property({ type: Boolean }) disabled = false;
+
+  private _generatedId = `radio-${Math.random().toString(36).substr(2, 9)}`;
+
+  get radioId() {
+    return this.inputId || this.getAttribute('id') || this._generatedId;
+  }
+
+  private onRadioChange(event: Event) {
+    const target = event.target as HTMLInputElement;
+    if (target.checked) {
+      this.dispatchEvent(
+        new CustomEvent('changed', { detail: this.value, bubbles: true, composed: true }),
+      );
+    }
+  }
+
+  override render() {
+    return html`
+      <label
+        for=${this.radioId}
+        class=${'radio-wrapper' + (this.disabled ? ' radio-wrapper--disabled' : '')}
+      >
+        <input
+          type="radio"
+          id=${this.radioId}
+          name=${this.name ?? ''}
+          value=${this.value ?? ''}
+          ?checked=${this.checked}
+          ?disabled=${this.disabled}
+          class="radio-input"
+          @change=${this.onRadioChange}
+        />
+        <span class="radio-circle"></span>
+        <span class="radio-label">${this.label}</span>
+      </label>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'candor-radio': CandorRadio;
+  }
+}

--- a/src/app/_candor/modal/modal.ts
+++ b/src/app/_candor/modal/modal.ts
@@ -1,0 +1,75 @@
+import { LitElement, html } from 'lit';
+import { customElement, property, query } from 'lit/decorators.js';
+import './modal.component.scss';
+import '../button/button';
+
+@customElement('candor-modal')
+export class CandorModal extends LitElement {
+  override createRenderRoot(): this {
+    return this;
+  }
+
+  @property() override title = '';
+  @property({ type: Boolean }) open = false;
+
+  @query('dialog') private dialogEl!: HTMLDialogElement;
+
+  readonly uid = `modal-${Math.random().toString(36).substr(2, 9)}`;
+
+  override updated(changed: Map<string, unknown>) {
+    if (changed.has('open') && this.dialogEl) {
+      if (this.open) {
+        if (!this.dialogEl.open) this.dialogEl.showModal();
+      } else {
+        if (this.dialogEl.open) this.dialogEl.close();
+      }
+    }
+  }
+
+  private close() {
+    this.dialogEl?.close();
+  }
+
+  private onClose() {
+    this.open = false;
+    this.dispatchEvent(new CustomEvent('open-change', { detail: false, bubbles: true, composed: true }));
+  }
+
+  private onBackdropClick(event: MouseEvent) {
+    if (event.target === this.dialogEl) {
+      this.close();
+    }
+  }
+
+  override render() {
+    return html`
+      <dialog
+        class="modal"
+        aria-modal="true"
+        aria-labelledby=${this.uid}
+        @click=${this.onBackdropClick}
+        @close=${this.onClose}
+      >
+        <div class="modal__panel" @click=${(e: Event) => e.stopPropagation()}>
+          <div class="modal__header">
+            <h2 id=${this.uid} class="modal__title">${this.title}</h2>
+            <candor-button variant="ghost" size="icon" aria-label="Close dialog" @clicked=${this.close}>
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">
+                <path d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+              </svg>
+            </candor-button>
+          </div>
+          <div class="modal__body">
+            <slot></slot>
+          </div>
+        </div>
+      </dialog>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'candor-modal': CandorModal;
+  }
+}

--- a/src/app/_candor/table/table.ts
+++ b/src/app/_candor/table/table.ts
@@ -1,0 +1,31 @@
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import './table.component.scss';
+
+@customElement('candor-table')
+export class CandorTable extends LitElement {
+  override createRenderRoot(): this {
+    return this;
+  }
+
+  @property({ type: Boolean }) compact = false;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.classList.add('table-host');
+  }
+
+  override updated() {
+    this.classList.toggle('table-host--compact', this.compact);
+  }
+
+  override render() {
+    return html`<slot></slot>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'candor-table': CandorTable;
+  }
+}

--- a/src/app/_candor/toast/toast.ts
+++ b/src/app/_candor/toast/toast.ts
@@ -1,0 +1,104 @@
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import './toast.component.scss';
+
+type ToastVariant = 'info' | 'success' | 'warning' | 'error';
+
+@customElement('candor-toast')
+export class CandorToast extends LitElement {
+  override createRenderRoot(): this {
+    return this;
+  }
+
+  @property() variant: ToastVariant = 'info';
+  @property() override title = '';
+  @property() message = '';
+  @property({ type: Boolean }) dismissible = true;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.classList.add('toast-host');
+  }
+
+  private dismiss() {
+    this.dispatchEvent(new CustomEvent('dismissed', { bubbles: true, composed: true }));
+  }
+
+  private renderIcon() {
+    switch (this.variant) {
+      case 'info':
+        return html`
+          <circle cx="12" cy="12" r="10" />
+          <line x1="12" y1="8" x2="12" y2="12" />
+          <line x1="12" y1="16" x2="12.01" y2="16" />
+        `;
+      case 'success':
+        return html`
+          <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+          <polyline points="22 4 12 14.01 9 11.01" />
+        `;
+      case 'warning':
+        return html`
+          <path
+            d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
+          />
+          <line x1="12" y1="9" x2="12" y2="13" />
+          <line x1="12" y1="17" x2="12.01" y2="17" />
+        `;
+      case 'error':
+        return html`
+          <circle cx="12" cy="12" r="10" />
+          <line x1="15" y1="9" x2="9" y2="15" />
+          <line x1="9" y1="9" x2="15" y2="15" />
+        `;
+    }
+  }
+
+  override render() {
+    const role = this.variant === 'warning' || this.variant === 'error' ? 'alert' : 'status';
+    return html`
+      <div class=${'toast toast--' + this.variant} role=${role}>
+        <svg
+          class="toast__icon"
+          aria-hidden="true"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          ${this.renderIcon()}
+        </svg>
+        <div class="toast__content">
+          ${this.title ? html`<div class="toast__title">${this.title}</div>` : ''}
+          <div class="toast__message">${this.message}</div>
+        </div>
+        ${this.dismissible
+          ? html`
+              <button class="toast__dismiss" @click=${this.dismiss} aria-label="Dismiss notification">
+                <svg
+                  aria-hidden="true"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            `
+          : ''}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'candor-toast': CandorToast;
+  }
+}

--- a/src/app/_candor/tooltip/tooltip.component.scss
+++ b/src/app/_candor/tooltip/tooltip.component.scss
@@ -1,4 +1,4 @@
-:host.tooltip {
+candor-tooltip {
   display: inline-block;
   position: relative;
 }

--- a/src/app/_candor/tooltip/tooltip.ts
+++ b/src/app/_candor/tooltip/tooltip.ts
@@ -1,0 +1,70 @@
+import { LitElement, html } from 'lit';
+import { customElement, property, state, query } from 'lit/decorators.js';
+import './tooltip.component.scss';
+
+type TooltipPosition = 'top' | 'bottom' | 'left' | 'right';
+
+@customElement('candor-tooltip')
+export class CandorTooltip extends LitElement {
+  override createRenderRoot(): this {
+    return this;
+  }
+
+  @property() text = '';
+  @property() position: TooltipPosition = 'top';
+
+  @state() private visible = false;
+  @state() private nudgeX = 0;
+
+  @query('.tooltip__bubble') private bubble?: HTMLDivElement;
+
+  private show() {
+    this.nudgeX = 0;
+    this.visible = true;
+    queueMicrotask(() => {
+      if (!this.bubble) return;
+      const { left, right } = this.bubble.getBoundingClientRect();
+      const margin = 8;
+      const vw = window.innerWidth;
+      if (left < margin) this.nudgeX = margin - left;
+      else if (right > vw - margin) this.nudgeX = vw - margin - right;
+    });
+  }
+
+  private hide() {
+    this.visible = false;
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('mouseenter', () => this.show());
+    this.addEventListener('mouseleave', () => this.hide());
+    this.addEventListener('focusin', () => this.show());
+    this.addEventListener('focusout', () => this.hide());
+    this.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.key === 'Escape') this.hide();
+    });
+    this.classList.add('tooltip');
+  }
+
+  override render() {
+    return html`
+      <slot></slot>
+      <div
+        aria-hidden="true"
+        class=${'tooltip__bubble tooltip__bubble--' +
+          this.position +
+          (this.visible ? ' tooltip__bubble--visible' : '')}
+        style="--nudge-x: ${this.nudgeX}px"
+      >
+        ${this.text}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'candor-tooltip': CandorTooltip;
+  }
+}

--- a/src/app/_components/alert/alert.component.scss
+++ b/src/app/_components/alert/alert.component.scss
@@ -1,5 +1,5 @@
 .comp-container {
-  app-toast {
+  candor-toast {
     animation: show-alert 200ms ease-out;
   }
 

--- a/src/app/_components/alert/alert.stories.ts
+++ b/src/app/_components/alert/alert.stories.ts
@@ -1,36 +1,27 @@
-import type { Meta, StoryObj } from '@storybook/angular';
-import { AlertComponent } from './alert.component';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+import './alert';
 
-const meta: Meta<AlertComponent> = {
+const meta: Meta = {
   title: 'App/Alert',
-  component: AlertComponent,
   tags: ['autodocs'],
+  render: (args) => html`
+    <cc-alert .alertMessage=${{ message: args['message'] ?? '' }}></cc-alert>
+  `,
   argTypes: {
-    alertMessage: {
-      control: 'object',
-    },
+    message: { control: 'text' },
   },
 };
 
 export default meta;
-type Story = StoryObj<AlertComponent>;
+type Story = StoryObj;
 
-export const Typical: Story = {
-  args: {},
-};
+export const Typical: Story = { args: {} };
 
 export const ColorCopied: Story = {
-  args: {
-    alertMessage: {
-      message: 'Color One Variant, #ffe1df, copied to clipboard.',
-    },
-  },
+  args: { message: 'Color One Variant, #ffe1df, copied to clipboard.' },
 };
 
 export const AppWarning: Story = {
-  args: {
-    alertMessage: {
-      message: 'Warning',
-    },
-  },
+  args: { message: 'Warning' },
 };

--- a/src/app/_components/alert/alert.ts
+++ b/src/app/_components/alert/alert.ts
@@ -1,0 +1,70 @@
+import { LitElement, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { random, times } from 'lodash-es';
+import '../../../app/_candor/toast/toast';
+import './alert.component.scss';
+
+export interface AlertMessageObj {
+  message: string;
+}
+
+@customElement('cc-alert')
+export class CcAlert extends LitElement {
+  override createRenderRoot(): this {
+    return this;
+  }
+
+  @property({ type: Object, attribute: false }) alertMessage: AlertMessageObj = { message: '' };
+
+  @state() private showAlert = false;
+  @state() private uniqId = '';
+
+  private timeout: ReturnType<typeof setTimeout> | null = null;
+
+  private generateRandomString(length: number) {
+    return times(length, () => random(35).toString(36)).join('');
+  }
+
+  private hideAlert() {
+    this.showAlert = false;
+    this.uniqId = '';
+    this.dispatchEvent(new CustomEvent('alert-closed', { detail: true, bubbles: true, composed: true }));
+  }
+
+  override updated(changed: Map<string, unknown>) {
+    if (!changed.has('alertMessage')) return;
+    const msg = this.alertMessage?.message;
+    if (msg) {
+      this.uniqId = this.generateRandomString(12);
+      this.showAlert = true;
+
+      if (this.timeout) clearTimeout(this.timeout);
+      this.timeout = setTimeout(() => {
+        this.showAlert = false;
+      }, 5000);
+    }
+  }
+
+  override render() {
+    return html`
+      <div class="comp-container">
+        ${this.showAlert
+          ? html`
+              <candor-toast
+                variant="success"
+                message=${this.alertMessage.message}
+                .dismissible=${false}
+              ></candor-toast>
+              <span class="msg-id" aria-hidden="true">${this.uniqId}</span>
+            `
+          : ''}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'cc-alert': CcAlert;
+  }
+}

--- a/src/app/_components/color-contrast/color-contrast.stories.ts
+++ b/src/app/_components/color-contrast/color-contrast.stories.ts
@@ -1,36 +1,32 @@
-import type { Meta, StoryObj } from '@storybook/angular';
-import { componentWrapperDecorator } from '@storybook/angular';
-import { ColorContrastComponent } from './color-contrast.component';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+import './color-contrast';
 
-const meta: Meta<ColorContrastComponent> = {
+const meta: Meta = {
   title: 'App/Color Contrast',
-  component: ColorContrastComponent,
   tags: ['autodocs'],
-  decorators: [
-    componentWrapperDecorator(
-      (story) =>
-        `<style>app-color-contrast { display: flex; flex: 1; }</style><div style="display:flex;height:200px;width:300px">${story}</div>`
-    ),
-  ],
+  render: (args) => html`
+    <style>cc-color-contrast { display: flex; flex: 1; }</style>
+    <div style="display:flex;height:200px;width:300px">
+      <cc-color-contrast
+        colorone=${args['colorOne'] ?? ''}
+        colortwo=${args['colorTwo'] ?? ''}
+        contrasttype=${args['contrastType'] ?? 'okca'}
+      ></cc-color-contrast>
+    </div>
+  `,
   argTypes: {
-    colorOne: {
-      control: 'color',
-    },
-    colorTwo: {
-      control: 'color',
-    },
+    colorOne: { control: 'color' },
+    colorTwo: { control: 'color' },
     contrastType: {
       options: ['okca', 'apca', 'bpca', 'deltaE', 'apca object'],
       control: { type: 'radio' },
-    },
-    debug: {
-      control: 'boolean',
     },
   },
 };
 
 export default meta;
-type Story = StoryObj<ColorContrastComponent>;
+type Story = StoryObj;
 
 export const Typical: Story = {};
 
@@ -44,16 +40,16 @@ export const OKCA: Story = {
 
 export const APCA: Story = {
   args: {
-    colorOne: 'white',
-    colorTwo: 'black',
+    colorOne: '#ffffff',
+    colorTwo: '#000000',
     contrastType: 'apca',
   },
 };
 
 export const WCAGEnhanced: Story = {
   args: {
-    colorOne: 'white',
-    colorTwo: 'black',
+    colorOne: '#ffffff',
+    colorTwo: '#000000',
     contrastType: 'bpca',
   },
 };
@@ -61,7 +57,7 @@ export const WCAGEnhanced: Story = {
 export const WCAGEnhancedEdgeCase: Story = {
   args: {
     colorOne: '#928f8f',
-    colorTwo: 'white',
+    colorTwo: '#ffffff',
     contrastType: 'bpca',
   },
 };
@@ -69,7 +65,7 @@ export const WCAGEnhancedEdgeCase: Story = {
 export const DeltaE: Story = {
   args: {
     colorOne: '#928f8f',
-    colorTwo: 'white',
+    colorTwo: '#ffffff',
     contrastType: 'deltaE',
   },
 };
@@ -77,7 +73,7 @@ export const DeltaE: Story = {
 export const ObjectContrast: Story = {
   args: {
     colorOne: '#928f8f',
-    colorTwo: 'white',
+    colorTwo: '#ffffff',
     contrastType: 'apca object',
   },
 };

--- a/src/app/_components/color-contrast/color-contrast.ts
+++ b/src/app/_components/color-contrast/color-contrast.ts
@@ -1,0 +1,77 @@
+import { LitElement, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { colorMetrics } from '../../services/color-metrics.service';
+import { colorUtil } from '../../services/color-util.service';
+import type { ContrastType } from '../../services/color-metrics.service';
+import './color-contrast.component.scss';
+
+@customElement('cc-color-contrast')
+export class CcColorContrast extends LitElement {
+  override createRenderRoot(): this {
+    return this;
+  }
+
+  @property({ attribute: 'colorone' }) colorOne = '';
+  @property({ attribute: 'colortwo' }) colorTwo = '';
+  @property({ attribute: 'contrasttype' }) contrastType: ContrastType | 'apca object' = 'okca';
+  @property({ type: Boolean }) debug = false;
+
+  @state() private contrastScore = NaN;
+
+  override updated(changed: Map<string, unknown>) {
+    if (changed.has('colorOne') || changed.has('colorTwo') || changed.has('contrastType')) {
+      this._computeScore();
+    }
+  }
+
+  private _computeScore() {
+    const { colorOne, colorTwo, contrastType } = this;
+    if (!colorOne || !colorTwo || !contrastType) {
+      if (this.debug) console.warn('contrast comp missing inputs');
+      return;
+    }
+
+    let calcType: ContrastType;
+    if (contrastType === 'apca object') {
+      calcType = 'apca';
+    } else if (contrastType === 'deltaE') {
+      calcType = 'deltaE';
+    } else {
+      calcType = contrastType;
+    }
+
+    const score = colorMetrics.getContrast(colorOne, colorTwo, calcType);
+
+    if (score && contrastType === 'apca object') {
+      this.contrastScore = colorUtil.getMinObjectDimension(score);
+      return;
+    }
+
+    this.contrastScore = score === null || score === undefined ? NaN : score;
+  }
+
+  get contrastAnnouncement() {
+    return isNaN(this.contrastScore) ? '' : `Contrast score: ${this.contrastScore}`;
+  }
+
+  override render() {
+    return html`
+      <div class="comp-container" aria-hidden="true">
+        <div class="score-container">
+          <div id="contrast-score" class="score">
+            ${this.contrastScore ? this.contrastScore : '!'}
+          </div>
+        </div>
+      </div>
+      <div class="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        ${this.contrastAnnouncement}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'cc-color-contrast': CcColorContrast;
+  }
+}

--- a/src/app/_components/color-picker/color-picker.stories.ts
+++ b/src/app/_components/color-picker/color-picker.stories.ts
@@ -1,82 +1,39 @@
-import type { Meta, StoryObj } from '@storybook/angular';
-import { ColorPickerComponent } from './color-picker.component';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+import './color-picker';
 
-// model() signals cause a runtime type extraction failure in Storybook's docs renderer
-// (value.replace is not a function). Use extractArgTypes override to bypass automatic extraction.
-const colorPickerArgTypes = {
-  label: {
-    control: 'text',
-    type: { name: 'string', required: false },
-    description: 'Accessible label for the color input.',
-    table: { defaultValue: { summary: 'Color' } },
-  },
-  color: {
-    control: 'color',
-    type: { name: 'string', required: false },
-    description: 'The current color value.',
-    table: { defaultValue: { summary: '' } },
-  },
-  comparedColor: {
-    control: 'color',
-    type: { name: 'string', required: false },
-    description: 'Optional compared color shown as a split swatch (two-way bindable via model()).',
-    table: { defaultValue: { summary: '' } },
-  },
-  inputId: {
-    control: 'text',
-    type: { name: 'string', required: false },
-    description: 'ID attribute for the hidden color input.',
-    table: { defaultValue: { summary: 'fg-color' } },
-  },
-  inputName: {
-    control: 'text',
-    type: { name: 'string', required: false },
-    description: 'Name attribute for the hidden color input.',
-    table: { defaultValue: { summary: 'foreground color' } },
-  },
-  debug: {
-    control: 'boolean',
-    type: { name: 'boolean', required: false },
-    description: 'Enable debug logging.',
-    table: { defaultValue: { summary: 'false' } },
-  },
-  selectedColor: {
-    control: false,
-    description: 'Emits the selected color string when the user picks a color.',
-    table: { type: { summary: 'string' }, category: 'Outputs' },
-  },
-};
-
-const meta: Meta<ColorPickerComponent> = {
+const meta: Meta = {
   title: 'App/Color Picker',
-  component: ColorPickerComponent,
   tags: ['autodocs'],
-  argTypes: colorPickerArgTypes as Meta<ColorPickerComponent>['argTypes'],
-  parameters: {
-    docs: {
-      extractArgTypes: () => colorPickerArgTypes,
-    },
+  render: (args) => html`
+    <cc-color-picker
+      inputid=${args['inputId'] ?? 'cp-story'}
+      inputname=${args['inputName'] ?? 'color'}
+      label=${args['label'] ?? 'Color'}
+      color=${args['color'] ?? ''}
+      comparedcolor=${args['comparedColor'] ?? ''}
+    ></cc-color-picker>
+  `,
+  argTypes: {
+    label: { control: 'text' },
+    color: { control: 'color' },
+    comparedColor: { control: 'color' },
+    inputId: { control: 'text' },
+    inputName: { control: 'text' },
   },
 };
 
 export default meta;
-type Story = StoryObj<ColorPickerComponent>;
+type Story = StoryObj;
 
 export const Typical: Story = {
-  args: {
-    color: '#3a86ff',
-  },
+  args: { color: '#3a86ff' },
 };
 
 export const WithComparedColor: Story = {
-  args: {
-    color: '#3a86ff',
-    comparedColor: '#ffbe0b',
-  },
+  args: { color: '#3a86ff', comparedColor: '#ffbe0b' },
 };
 
 export const Empty: Story = {
-  args: {
-    comparedColor: '',
-  },
+  args: { comparedColor: '' },
 };

--- a/src/app/_components/color-picker/color-picker.ts
+++ b/src/app/_components/color-picker/color-picker.ts
@@ -1,0 +1,82 @@
+import { LitElement, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import './color-picker.component.scss';
+
+@customElement('cc-color-picker')
+export class CcColorPicker extends LitElement {
+  override createRenderRoot(): this {
+    return this;
+  }
+
+  @property({ attribute: 'inputid' }) inputId = 'fg-color';
+  @property({ attribute: 'inputname' }) inputName = 'foreground color';
+  @property() label = 'Color';
+  @property() color = '';
+  @property({ attribute: 'comparedcolor' }) comparedColor = '';
+  @property({ type: Boolean }) debug = false;
+
+  @state() private uiColor = '';
+  @state() private uiComparedColor = '';
+
+  override updated(changed: Map<string, unknown>) {
+    if (changed.has('color')) {
+      this._handleColorChange(this.color);
+      this._updateInputValue(this.color);
+      this._resetUiComparedColor();
+    }
+    if (changed.has('comparedColor')) {
+      this.uiComparedColor = this.comparedColor;
+    }
+  }
+
+  private _handleColorChange(inputColor: string) {
+    this.uiColor = inputColor;
+    this.dispatchEvent(
+      new CustomEvent('selected-color', { detail: inputColor, bubbles: true, composed: true }),
+    );
+  }
+
+  private _handleInputEvent(event: Event) {
+    const inputElement = event.target as HTMLInputElement;
+    const selectedColor = inputElement.value;
+    this._resetUiComparedColor();
+    this._handleColorChange(selectedColor);
+  }
+
+  private _resetUiComparedColor() {
+    this.uiComparedColor = 'transparent';
+  }
+
+  private _updateInputValue(color: string) {
+    const targetInput = this.querySelector(`#${this.inputId}`) as HTMLInputElement;
+    if (!targetInput) {
+      if (this.debug) console.error(`no input found with id: ${this.inputId}`);
+      return;
+    }
+    targetInput.value = color;
+  }
+
+  override render() {
+    return html`
+      <div class="comp-container">
+        <label class="sr-only" for=${this.inputId}>${this.label}</label>
+        <input
+          type="color"
+          id=${this.inputId}
+          name=${this.inputName}
+          @input=${this._handleInputEvent}
+        />
+        <div
+          class="color-preview"
+          style="border-color: ${this.uiComparedColor}; background-color: ${this.uiColor}"
+        ></div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'cc-color-picker': CcColorPicker;
+  }
+}

--- a/src/app/_components/color-slider/color-slider.stories.ts
+++ b/src/app/_components/color-slider/color-slider.stories.ts
@@ -1,79 +1,53 @@
-import type { Meta, StoryObj } from '@storybook/angular';
-import { ColorSliderComponent } from './color-slider.component';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+import './color-slider';
 
-const meta: Meta<ColorSliderComponent> = {
+const meta: Meta = {
   title: 'App/Color Slider',
-  component: ColorSliderComponent,
   tags: ['autodocs'],
+  render: (args) => html`
+    <div style="width: 400px">
+      <cc-color-slider
+        id=${args['id'] ?? 'slider-story'}
+        name=${args['name'] ?? 'color-slider'}
+        label=${args['label'] ?? 'Lightness'}
+        color=${args['color'] ?? ''}
+        ?constantchroma=${args['constantChroma'] ?? false}
+        ?showgradient=${args['showGradient'] ?? false}
+        ?debug=${args['debug'] ?? false}
+      ></cc-color-slider>
+    </div>
+  `,
   argTypes: {
-    label: {
-      control: 'text',
-    },
-    color: {
-      control: 'color',
-    },
-    id: {
-      control: 'text',
-    },
-    name: {
-      control: 'text',
-    },
-    constantChroma: {
-      control: 'boolean',
-    },
-    showGradient: {
-      control: 'boolean',
-    },
-    resetSlider: {
-      control: 'object',
-    },
-    debug: {
-      control: 'boolean',
-    },
+    label: { control: 'text' },
+    color: { control: 'color' },
+    id: { control: 'text' },
+    name: { control: 'text' },
+    constantChroma: { control: 'boolean' },
+    showGradient: { control: 'boolean' },
+    debug: { control: 'boolean' },
   },
 };
 
 export default meta;
-type Story = StoryObj<ColorSliderComponent>;
+type Story = StoryObj;
 
 export const Typical: Story = {
-  args: {
-    color: '#3a86ff',
-    showGradient: true,
-  },
+  args: { color: '#3a86ff', showGradient: true },
 };
 
 export const RgbRed: Story = {
-  args: {
-    color: 'red',
-    constantChroma: true,
-    showGradient: true,
-    debug: true,
-  },
+  args: { color: '#ff0000', constantChroma: true, showGradient: true, debug: true },
 };
 
 export const RgbGreen: Story = {
-  args: {
-    color: 'green',
-    constantChroma: true,
-    showGradient: true,
-    debug: true,
-  },
+  args: { color: '#008000', constantChroma: true, showGradient: true, debug: true },
 };
 
 export const RgbBlue: Story = {
-  args: {
-    color: 'blue',
-    constantChroma: true,
-    showGradient: true,
-    debug: true,
-  },
+  args: { color: '#0000ff', constantChroma: true, showGradient: true, debug: true },
 };
 
 export const NoHueColor: Story = {
-  args: {
-    color: 'gray',
-    showGradient: true,
-    debug: true,
-  },
+  args: { color: '#808080', showGradient: true, debug: true },
 };

--- a/src/app/_components/color-slider/color-slider.ts
+++ b/src/app/_components/color-slider/color-slider.ts
@@ -1,0 +1,216 @@
+import { LitElement, html } from 'lit';
+import { customElement, property, state, query } from 'lit/decorators.js';
+import { colorUtil } from '../../services/color-util.service';
+import './color-slider.component.scss';
+
+export interface ResetObject {
+  reset: true;
+}
+
+@customElement('cc-color-slider')
+export class CcColorSlider extends LitElement {
+  override createRenderRoot(): this {
+    return this;
+  }
+
+  @property() override id = 'slider-0';
+  @property() name = 'color-slider';
+  @property() label = 'Lightness';
+  @property() color = '';
+  @property({ type: Boolean, attribute: 'constantchroma' }) constantChroma = false;
+  @property({ type: Boolean, attribute: 'showgradient' }) showGradient = false;
+  @property({ type: Object, attribute: false }) resetSlider: ResetObject | null = null;
+  @property({ type: Boolean }) debug = false;
+
+  @state() private slideMin = NaN;
+  @state() private slideMax = NaN;
+  @state() private slideInterval = NaN;
+  @state() private value = NaN;
+  @state() private initValue = NaN;
+  @state() private devColorVariant = '';
+
+  private readonly rangeDescId = `slider-range-${Math.random().toString(36).slice(2, 9)}`;
+
+  get valueText() {
+    return isNaN(this.value) ? '' : `${Math.round(this.value * 100)}%`;
+  }
+
+  get rangeDescription() {
+    if (isNaN(this.slideMin) || isNaN(this.slideMax)) return '';
+    return `Lightness range: ${Math.round(this.slideMin * 100)}% to ${Math.round(this.slideMax * 100)}%`;
+  }
+
+  override updated(changed: Map<string, unknown>) {
+    const needsRecompute =
+      changed.has('color') ||
+      changed.has('showGradient') ||
+      changed.has('resetSlider') ||
+      changed.has('constantChroma');
+
+    if (!needsRecompute) return;
+
+    const sliderContainer = this.querySelector(`#cc-${this.id}`) as HTMLElement;
+    if (!sliderContainer) {
+      if (this.debug) console.warn('no slide container yet');
+      return;
+    }
+
+    if (!this.color) {
+      if (this.debug) console.error('no color specified');
+      return;
+    }
+
+    this._getAndSetLightnessRange(this.color, { constantChroma: this.constantChroma });
+    this._gradient(this.showGradient ? 'on' : 'off');
+
+    if (this.resetSlider && this.initValue) {
+      this._reset();
+    }
+  }
+
+  private _sendInitialLightVariant() {
+    this.dispatchEvent(
+      new CustomEvent('color-variant', { detail: this.color, bubbles: true, composed: true }),
+    );
+    if (this.debug) this.devColorVariant = this.color;
+  }
+
+  private async _getAndSetLightnessRange(color: string, options?: { constantChroma: boolean }) {
+    const rangeObject = await colorUtil.getMinMaxLight(color);
+    if (!rangeObject) {
+      console.error(`no range object for color ${color}`);
+      return;
+    }
+
+    this._sendInitialLightVariant();
+
+    this.slideMin = 0;
+    this.slideMax = 1;
+
+    if (options?.constantChroma) {
+      this.slideMin = rangeObject.lightMin;
+      this.slideMax = rangeObject.lightMax;
+    }
+
+    this.slideInterval = (this.slideMax - this.slideMin) / 80;
+
+    const initialSlideValue = rangeObject.originalCoords[0];
+    this.initValue = initialSlideValue;
+    this.value = initialSlideValue;
+
+    this._redefineGradientStops(this.slideMin, this.slideMax);
+  }
+
+  private _handleSliding(event: Event) {
+    const inputElem = event.target as HTMLInputElement;
+    if (inputElem && this.color) {
+      const lightValue = parseFloat(inputElem.value);
+      const lightnessVariant = colorUtil.createSrgbColor(this.color, lightValue);
+
+      if (this.debug) {
+        console.log(`slide modding ${this.color} to ${lightnessVariant}`);
+        this.devColorVariant = lightnessVariant ?? '';
+      }
+
+      this.dispatchEvent(
+        new CustomEvent('color-variant', { detail: lightnessVariant, bubbles: true, composed: true }),
+      );
+    } else {
+      console.error('no color specified');
+    }
+  }
+
+  private _reset() {
+    const element = this.querySelector(`#${this.id}`) as HTMLInputElement;
+    if (!element) {
+      console.error(`no element found with id: ${this.id}`);
+      return;
+    }
+    if (!isNaN(this.initValue)) {
+      element.value = this.initValue.toString();
+    }
+  }
+
+  private _gradient(val: 'on' | 'off') {
+    const targetElem = this.querySelector(`#cc-${this.id}`) as HTMLElement;
+    if (!targetElem) {
+      if (this.debug) console.warn('no elem to assign gradient to.');
+      return;
+    }
+    targetElem.style.background =
+      val === 'on' ? 'var(--gradient-background)' : 'var(--default-background)';
+  }
+
+  private _redefineGradientStops(lightMin: number, lightMax: number) {
+    if (!this.color) return;
+
+    const targetElement = this.querySelector(`#cc-${this.id}`) as HTMLElement;
+    if (!targetElement) return;
+
+    const stops = [
+      '--grad-stop-0',
+      '--grad-stop-1',
+      '--grad-stop-2',
+      '--grad-stop-3',
+      '--grad-stop-4',
+      '--grad-stop-5',
+    ];
+
+    const stopInterval = (lightMax - lightMin) / (stops.length - 1);
+    const stopVals: (string | null)[] = [];
+
+    for (let i = 0; i < stops.length; i++) {
+      const targetLight = stopInterval * i + lightMin;
+      stopVals.push(colorUtil.createSrgbColor(this.color, targetLight));
+    }
+
+    for (let i = 0; i < stops.length; i++) {
+      const stopColor = stopVals[i];
+      if (stopColor) targetElement.style.setProperty(stops[i], stopColor);
+    }
+  }
+
+  override render() {
+    return html`
+      <div id=${'cc-' + this.id} class="comp-container">
+        <label for=${this.id} class="sr-only">${this.label}</label>
+        ${this.slideMin !== this.slideMax
+          ? html`
+              <span id=${this.rangeDescId} class="sr-only">${this.rangeDescription}</span>
+              <input
+                type="range"
+                name=${this.name}
+                id=${this.id}
+                min=${this.slideMin}
+                max=${this.slideMax}
+                step=${this.slideInterval}
+                .value=${String(this.value)}
+                aria-valuetext=${this.valueText}
+                aria-describedby=${this.rangeDescId}
+                @input=${this._handleSliding}
+              />
+            `
+          : !isNaN(this.slideMin)
+            ? html`
+                <div class="special-case">
+                  <div>!</div>
+                </div>
+              `
+            : ''}
+      </div>
+      <div class="dev-overlay ${this.debug ? 'active' : ''}">
+        <h2>dev overlay</h2>
+        <div
+          class="light-variant-chip"
+          style="border-color: ${this.devColorVariant}; background-color: ${this.color}"
+        ></div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'cc-color-slider': CcColorSlider;
+  }
+}

--- a/src/app/_components/copy-to-clipboard-button/copy-to-clipboard-button.stories.ts
+++ b/src/app/_components/copy-to-clipboard-button/copy-to-clipboard-button.stories.ts
@@ -1,40 +1,33 @@
-import type { Meta, StoryObj } from '@storybook/angular';
-import { CopyToClipboardButtonComponent } from './copy-to-clipboard-button.component';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+import './copy-to-clipboard-button';
 
-const meta: Meta<CopyToClipboardButtonComponent> = {
+const meta: Meta = {
   title: 'App/Copy to Clipboard Button',
-  component: CopyToClipboardButtonComponent,
   tags: ['autodocs'],
+  render: (args) => html`
+    <cc-copy-to-clipboard-button
+      color=${args['color'] ?? ''}
+      label=${args['label'] ?? 'Copy to Clipboard'}
+      ?debug=${args['debug'] ?? false}
+    ></cc-copy-to-clipboard-button>
+  `,
   argTypes: {
-    label: {
-      control: 'text',
-    },
-    color: {
-      control: 'color',
-    },
-    debug: {
-      control: 'boolean',
-    },
+    label: { control: 'text' },
+    color: { control: 'color' },
+    debug: { control: 'boolean' },
   },
 };
 
 export default meta;
-type Story = StoryObj<CopyToClipboardButtonComponent>;
+type Story = StoryObj;
 
-export const Typical: Story = {
-  args: {},
-};
+export const Typical: Story = { args: {} };
 
 export const SomethingToCopy: Story = {
-  args: {
-    color: 'red',
-    debug: true,
-  },
+  args: { color: '#ff0000', debug: true },
 };
 
 export const NothingToCopy: Story = {
-  args: {
-    color: '',
-    debug: true,
-  },
+  args: { color: '', debug: true },
 };

--- a/src/app/_components/copy-to-clipboard-button/copy-to-clipboard-button.ts
+++ b/src/app/_components/copy-to-clipboard-button/copy-to-clipboard-button.ts
@@ -1,0 +1,68 @@
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import './copy-to-clipboard-button.component.scss';
+
+@customElement('cc-copy-to-clipboard-button')
+export class CcCopyToClipboardButton extends LitElement {
+  override createRenderRoot(): this {
+    return this;
+  }
+
+  @property() color = '';
+  @property() label = 'Copy to Clipboard';
+  @property({ type: Boolean }) debug = false;
+
+  private async copyToClipboard() {
+    if (!this.color) {
+      if (this.debug) console.warn('no color provided to copy');
+      return;
+    }
+
+    const colorSansHex = this.color.replace('#', '');
+
+    try {
+      await navigator.clipboard.writeText(colorSansHex);
+      this.dispatchEvent(
+        new CustomEvent('copy-event', {
+          detail: { copied: true, color: colorSansHex },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+      if (this.debug) console.log(this.color, 'copied to clipboard');
+    } catch (err) {
+      this.dispatchEvent(
+        new CustomEvent('copy-event', {
+          detail: { copied: false, color: colorSansHex },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+      console.error('Failed to copy text: ', err);
+    }
+  }
+
+  override render() {
+    return html`
+      <div class="comp-container">
+        <button aria-label=${this.label} ?disabled=${!this.color} @click=${this.copyToClipboard}>
+          <div class="svg-container" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" x="0px" y="0px">
+              <path
+                fill-rule="evenodd"
+                d="M384,608 L384,624 L368,624 L368,608 L384,608 Z M370,622 L382,622 L382,610 L370,610 L370,622 Z M362,602 L362,614 L366,614 L366,616 L360,616 L360,600 L376,600 L376,606 L374,606 L374,602 L362,602 Z"
+                transform="translate(-360 -600)"
+              />
+            </svg>
+          </div>
+        </button>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'cc-copy-to-clipboard-button': CcCopyToClipboardButton;
+  }
+}

--- a/src/app/_components/metadata/metadata.stories.ts
+++ b/src/app/_components/metadata/metadata.stories.ts
@@ -1,29 +1,27 @@
-import type { Meta, StoryObj } from '@storybook/angular';
-import { MetadataComponent } from './metadata.component';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+import './metadata';
 
-const meta: Meta<MetadataComponent> = {
+const meta: Meta = {
   title: 'App/Metadata Readout',
-  component: MetadataComponent,
   tags: ['autodocs'],
+  render: (args) => html`
+    <cc-metadata
+      colorone=${args['colorOne'] ?? ''}
+      colortwo=${args['colorTwo'] ?? ''}
+    ></cc-metadata>
+  `,
   argTypes: {
-    colorOne: {
-      control: 'color',
-    },
-    colorTwo: {
-      control: 'color',
-    },
-    debug: {
-      control: 'boolean',
-    },
+    colorOne: { control: 'color' },
+    colorTwo: { control: 'color' },
+    debug: { control: 'boolean' },
   },
 };
 
 export default meta;
-type Story = StoryObj<MetadataComponent>;
+type Story = StoryObj;
 
-export const Typical: Story = {
-  args: {},
-};
+export const Typical: Story = { args: {} };
 
 export const Populated: Story = {
   args: {

--- a/src/app/_components/metadata/metadata.ts
+++ b/src/app/_components/metadata/metadata.ts
@@ -1,0 +1,231 @@
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { colorUtil, type ColorMetaObj } from '../../services/color-util.service';
+import { colorMetrics } from '../../services/color-metrics.service';
+import '../../_candor/button/button';
+import '../../_candor/table/table';
+import '../../_candor/tooltip/tooltip';
+import './metadata.component.scss';
+
+interface DifferencesDataObj {
+  deltaE: number;
+  okca: number;
+  wcag2Old: number;
+  wcag2New: number;
+  apca: number;
+}
+
+interface SuccessesObj {
+  text: 'pass' | 'fail' | null;
+  largeText: 'pass' | 'fail' | null;
+  nonText: 'pass' | 'fail' | null;
+  objectMinDimension: number | string;
+}
+
+const INFO_SVG = html`
+  <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <path
+      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+    />
+  </svg>
+`;
+
+@customElement('cc-metadata')
+export class CcMetadata extends LitElement {
+  override createRenderRoot(): this {
+    return this;
+  }
+
+  @property({ attribute: 'colorone' }) colorOne = '';
+  @property({ attribute: 'colortwo' }) colorTwo = '';
+  @property({ type: Boolean }) debug = false;
+
+  get colorOneMeta(): ColorMetaObj | null {
+    if (!this.colorOne) return null;
+    return colorUtil.getColorMeta(this.colorOne);
+  }
+
+  get colorTwoMeta(): ColorMetaObj | null {
+    if (!this.colorTwo) return null;
+    return colorUtil.getColorMeta(this.colorTwo);
+  }
+
+  get differences(): DifferencesDataObj {
+    const result: DifferencesDataObj = {
+      deltaE: NaN,
+      okca: NaN,
+      wcag2Old: NaN,
+      wcag2New: NaN,
+      apca: NaN,
+    };
+    if (!this.colorOne || !this.colorTwo) return result;
+
+    result.deltaE = colorUtil.calcDeltaE(this.colorOne, this.colorTwo) ?? NaN;
+    result.okca = colorMetrics.getContrast(this.colorOne, this.colorTwo, 'okca') ?? NaN;
+    result.wcag2New = colorMetrics.getContrast(this.colorOne, this.colorTwo, 'bpca') ?? NaN;
+    result.wcag2Old = colorUtil.calcWcag2(this.colorOne, this.colorTwo) ?? NaN;
+    result.apca = colorMetrics.getContrast(this.colorOne, this.colorTwo, 'apca') ?? NaN;
+
+    return result;
+  }
+
+  get successes(): SuccessesObj {
+    const result: SuccessesObj = {
+      text: null,
+      largeText: null,
+      nonText: null,
+      objectMinDimension: NaN,
+    };
+    if (!this.colorOne || !this.colorTwo) return result;
+
+    const okcaScore = colorMetrics.getContrast(this.colorOne, this.colorTwo, 'okca');
+    const apcaScore = colorMetrics.getContrast(this.colorOne, this.colorTwo, 'apca');
+
+    if (okcaScore == null || !apcaScore) return result;
+    if (okcaScore < 0 || Math.abs(apcaScore) < 0) return result;
+
+    result.text = okcaScore >= 4.5 ? 'pass' : 'fail';
+    result.largeText = okcaScore >= 3 ? 'pass' : 'fail';
+    result.nonText = okcaScore >= 3 ? 'pass' : 'fail';
+    const minDimension = colorUtil.getMinObjectDimension(apcaScore);
+    result.objectMinDimension = Number.isNaN(minDimension) ? 'invisible' : minDimension;
+
+    return result;
+  }
+
+  private _emitNote(note: string) {
+    this.dispatchEvent(
+      new CustomEvent('note-requested', { detail: note, bubbles: true, composed: true }),
+    );
+  }
+
+  override render() {
+    const s = this.successes;
+    const d = this.differences;
+    const m1 = this.colorOneMeta;
+    const m2 = this.colorTwoMeta;
+
+    return html`
+      <div class="comp-container">
+        <div>
+          <h3>Successes and Minimums</h3>
+          <candor-table .compact=${true}>
+            <table>
+              <caption class="sr-only">Various pass, fails or minimum dimensions related to visual elements.</caption>
+              <thead class="sr-only"><tr><th>Criteria</th><th>Value</th></tr></thead>
+              <tbody>
+                <tr><td class="label">Text</td><td class="numeric">${s.text}</td></tr>
+                <tr><td class="label">Large Text</td><td class="numeric">${s.largeText}</td></tr>
+                <tr><td class="label">Non-text</td><td class="numeric">${s.nonText}</td></tr>
+                <tr>
+                  <td class="label label--with-info">
+                    Object
+                    <candor-tooltip text="About Object" position="right">
+                      <candor-button variant="ghost" size="icon" aria-label="About Object" @clicked=${() => this._emitNote('apca object')}>${INFO_SVG}</candor-button>
+                    </candor-tooltip>
+                  </td>
+                  <td class="numeric">${s.objectMinDimension}</td>
+                </tr>
+              </tbody>
+            </table>
+          </candor-table>
+        </div>
+
+        <div>
+          <h3>Differences</h3>
+          <candor-table .compact=${true}>
+            <table>
+              <caption class="sr-only">Differences between Foreground Color and Background Color.</caption>
+              <thead class="sr-only"><tr><th>Measurement</th><th>Value</th></tr></thead>
+              <tbody>
+                <tr>
+                  <td class="label label--with-info">
+                    Delta E
+                    <candor-tooltip text="About Delta E" position="right">
+                      <candor-button variant="ghost" size="icon" aria-label="About Delta E" @clicked=${() => this._emitNote('deltaE')}>${INFO_SVG}</candor-button>
+                    </candor-tooltip>
+                  </td>
+                  <td class="numeric">${d.deltaE}</td>
+                </tr>
+                <tr>
+                  <td class="label label--with-info">
+                    OKCA
+                    <candor-tooltip text="About OKCA" position="right">
+                      <candor-button variant="ghost" size="icon" aria-label="About OKCA" @clicked=${() => this._emitNote('okca')}>${INFO_SVG}</candor-button>
+                    </candor-tooltip>
+                  </td>
+                  <td class="numeric">${d.okca}</td>
+                </tr>
+                <tr>
+                  <td class="label label--with-info">
+                    Perceptual contrast
+                    <candor-tooltip text="About Perceptual contrast" position="right">
+                      <candor-button variant="ghost" size="icon" aria-label="About Perceptual contrast" @clicked=${() => this._emitNote('apca')}>${INFO_SVG}</candor-button>
+                    </candor-tooltip>
+                  </td>
+                  <td class="numeric">${d.apca}</td>
+                </tr>
+                <tr>
+                  <td class="label label--with-info">
+                    WCAG 2 compatible
+                    <candor-tooltip text="About WCAG 2 compatible" position="right">
+                      <candor-button variant="ghost" size="icon" aria-label="About WCAG 2 compatible" @clicked=${() => this._emitNote('bpca')}>${INFO_SVG}</candor-button>
+                    </candor-tooltip>
+                  </td>
+                  <td class="numeric">${d.wcag2New}</td>
+                </tr>
+                <tr>
+                  <td class="label label--with-info">
+                    WCAG 2
+                    <candor-tooltip text="About WCAG 2" position="right">
+                      <candor-button variant="ghost" size="icon" aria-label="About WCAG 2" @clicked=${() => this._emitNote('wcag2')}>${INFO_SVG}</candor-button>
+                    </candor-tooltip>
+                  </td>
+                  <td class="numeric">${d.wcag2Old}</td>
+                </tr>
+              </tbody>
+            </table>
+          </candor-table>
+        </div>
+
+        <div>
+          <h3>Foreground Color</h3>
+          <candor-table .compact=${true}>
+            <table>
+              <caption class="sr-only">Foreground Color Metadata</caption>
+              <thead class="sr-only"><tr><th>Measurement</th><th>Value</th></tr></thead>
+              <tbody>
+                <tr><td class="label">Saturation</td><td class="numeric">${m1?.saturation}</td></tr>
+                <tr><td class="label">Lightness</td><td class="numeric">${m1?.lightness}</td></tr>
+                <tr><td class="label">Chroma</td><td class="numeric">${m1?.chroma}</td></tr>
+                <tr><td class="label">Hue</td><td class="numeric">${m1?.hue}</td></tr>
+              </tbody>
+            </table>
+          </candor-table>
+        </div>
+
+        <div>
+          <h3>Background Color</h3>
+          <candor-table .compact=${true}>
+            <table>
+              <caption class="sr-only">Background Color Metadata</caption>
+              <thead class="sr-only"><tr><th>Measurement</th><th>Value</th></tr></thead>
+              <tbody>
+                <tr><td class="label">Saturation</td><td class="numeric">${m2?.saturation}</td></tr>
+                <tr><td class="label">Lightness</td><td class="numeric">${m2?.lightness}</td></tr>
+                <tr><td class="label">Chroma</td><td class="numeric">${m2?.chroma}</td></tr>
+                <tr><td class="label">Hue</td><td class="numeric">${m2?.hue}</td></tr>
+              </tbody>
+            </table>
+          </candor-table>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'cc-metadata': CcMetadata;
+  }
+}

--- a/src/app/_components/palette-table/palette-table.ts
+++ b/src/app/_components/palette-table/palette-table.ts
@@ -1,0 +1,160 @@
+import { LitElement, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { colorUtil, type TableColorCell, type TableData } from '../../services/color-util.service';
+import '../tone-picker/tone-picker';
+import type { GridRow, GridCell } from '../tone-picker/tone-picker';
+import './palette-table.component.scss';
+
+@customElement('cc-palette-table')
+export class CcPaletteTable extends LitElement {
+  override createRenderRoot(): this {
+    return this;
+  }
+
+  @property() color = '';
+  @property({ type: Boolean }) debug = false;
+
+  @state() private dataStruct: TableData = [];
+
+  readonly minDelta = 11;
+
+  override updated(changed: Map<string, unknown>) {
+    if (changed.has('color')) {
+      this._getTableData(this.color);
+    }
+  }
+
+  get tonePickerRows(): GridRow[] {
+    const data = this.dataStruct;
+    if (!data.length) return [];
+    const { lightnesses, chromas, cellMap } = this._buildIndex(data);
+    return lightnesses.map((l) => ({
+      rowHeader: l.toFixed(2),
+      cells: chromas.map((c): GridCell => {
+        const cell = cellMap.get(this._cellKey(l, c));
+        if (cell) {
+          return {
+            label: cell.color,
+            background: cell.color,
+            value: { l: cell.lightness, c: cell.chroma, h: cell.hue },
+            disabled: false,
+          };
+        }
+        return { label: '', disabled: true };
+      }),
+    }));
+  }
+
+  get tonePickerHeaders(): string[] {
+    const data = this.dataStruct;
+    if (!data.length) return [];
+    const { chromas } = this._buildIndex(data);
+    return chromas.map((c) => c.toFixed(2));
+  }
+
+  get selectedOklch(): string | null {
+    const hex = this.color;
+    if (!hex) return null;
+    try {
+      return colorUtil.hexToOklchString(hex);
+    } catch {
+      return null;
+    }
+  }
+
+  private _onTonePickerSelect(event: CustomEvent) {
+    const oklch = event.detail as string;
+    const parsed = this._parseOklch(oklch);
+    if (!parsed) return;
+
+    const { cellMap } = this._buildIndex(this.dataStruct);
+    for (const [, cell] of cellMap) {
+      if (
+        Math.abs(cell.lightness - parsed.l) < 0.001 &&
+        Math.abs(cell.chroma - parsed.c) < 0.001
+      ) {
+        this.dispatchEvent(
+          new CustomEvent('selected-color', { detail: cell, bubbles: true, composed: true }),
+        );
+        return;
+      }
+    }
+    const fallback: TableColorCell = {
+      color: oklch,
+      lightness: NaN,
+      chroma: NaN,
+      hue: NaN,
+      deltaE: NaN,
+      deltaLightness: NaN,
+      deltaChroma: NaN,
+    };
+    this.dispatchEvent(
+      new CustomEvent('selected-color', { detail: fallback, bubbles: true, composed: true }),
+    );
+  }
+
+  private _getTableData(color: string) {
+    if (!color) {
+      if (this.debug) console.warn('no color for palette table');
+      this.dataStruct = [];
+      return;
+    }
+    this.dataStruct = colorUtil.generateAdaptiveVariants(color, this.minDelta);
+  }
+
+  private _buildIndex(data: TableData) {
+    const cellMap = new Map<string, TableColorCell>();
+    const chromaSet = new Set<number>();
+    const lightnessSet = new Set<number>();
+
+    for (const row of data) {
+      for (const cell of row) {
+        chromaSet.add(cell.chroma);
+        lightnessSet.add(cell.lightness);
+        cellMap.set(this._cellKey(cell.lightness, cell.chroma), cell);
+      }
+    }
+
+    const chromas = [...chromaSet].sort((a, b) => a - b);
+    const lightnesses = [...lightnessSet].sort((a, b) => b - a);
+
+    return { lightnesses, chromas, cellMap };
+  }
+
+  private _cellKey(l: number, c: number): string {
+    return `${Math.round(l * 1000)},${Math.round(c * 1000)}`;
+  }
+
+  private _parseOklch(value: string): { l: number; c: number; h: number } | null {
+    const m = value.match(/oklch\(\s*([\d.]+)\s+([\d.]+)\s+([\d.]+)\s*\)/);
+    if (!m) return null;
+    return { l: parseFloat(m[1]), c: parseFloat(m[2]), h: parseFloat(m[3]) };
+  }
+
+  override render() {
+    return html`
+      <div class="comp-container">
+        ${this.tonePickerRows.length
+          ? html`
+              <cc-tone-picker
+                .rows=${this.tonePickerRows}
+                .columnHeaders=${this.tonePickerHeaders}
+                size="small"
+                hideHeaders
+                hideUi
+                selectedValue=${this.selectedOklch ?? ''}
+                ariaLabel=${'Color tones — hue ' + (this.dataStruct[0]?.[0]?.hue?.toFixed(0) ?? '') + '°'}
+                @color-select=${this._onTonePickerSelect}
+              ></cc-tone-picker>
+            `
+          : ''}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'cc-palette-table': CcPaletteTable;
+  }
+}

--- a/src/app/_components/tone-picker/tone-picker.component.scss
+++ b/src/app/_components/tone-picker/tone-picker.component.scss
@@ -1,4 +1,4 @@
-:host {
+cc-tone-picker {
   display: block;
   font-family: var(--font-family-accessible);
 }

--- a/src/app/_components/tone-picker/tone-picker.ts
+++ b/src/app/_components/tone-picker/tone-picker.ts
@@ -1,0 +1,292 @@
+import { LitElement, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import './tone-picker.component.scss';
+
+export interface GridCell {
+  label: string;
+  value?: unknown;
+  background?: string;
+  disabled?: boolean;
+}
+
+export interface GridRow {
+  rowHeader?: string;
+  cells: GridCell[];
+}
+
+@customElement('cc-tone-picker')
+export class CcTonePicker extends LitElement {
+  override createRenderRoot(): this {
+    return this;
+  }
+
+  @property({ type: Array }) rows: GridRow[] = [];
+  @property({ type: Array, attribute: 'columnheaders' }) columnHeaders: string[] = [];
+  @property({ attribute: 'arialabel' }) override ariaLabel: string | null = null;
+  @property() size: 'small' | 'normal' = 'normal';
+  @property({ attribute: 'selectedvalue' }) selectedValue: string | null = null;
+  @property({ type: Boolean, attribute: 'hideheaders' }) hideHeaders = false;
+  @property({ type: Boolean, attribute: 'hideui' }) hideUi = false;
+
+  @state() private focusedRow = 0;
+  @state() private focusedCol = 0;
+  @state() private selectedRow = -1;
+  @state() private selectedCol = -1;
+  @state() private selectedColor: string | null = null;
+  @state() private announcement = '';
+
+  readonly hintId = `gamut-hint-${Math.random().toString(36).slice(2, 9)}`;
+  private edgeToggle = false;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    const { r, c } = this._findFirstInGamut();
+    this.focusedRow = r;
+    this.focusedCol = c;
+    this.addEventListener('keydown', this._onKeydown.bind(this) as EventListener);
+  }
+
+  override updated(changed: Map<string, unknown>) {
+    if (changed.has('selectedValue') && this.selectedValue) {
+      const parsed = this._parseOklch(this.selectedValue);
+      if (!parsed) return;
+      const match = this._findCellByLC(parsed.l, parsed.c);
+      if (match) {
+        this.selectedRow = match.r;
+        this.selectedCol = match.col;
+        this.selectedColor = this.selectedValue;
+        this.announcement = `Selected: ${this.selectedValue}`;
+      }
+    }
+    if (changed.has('rows')) {
+      const { r, c } = this._findFirstInGamut();
+      this.focusedRow = r;
+      this.focusedCol = c;
+    }
+  }
+
+  get setsize() {
+    let pos = 0;
+    for (const row of this.rows) {
+      for (const cell of row.cells) {
+        if (!cell.disabled) pos++;
+      }
+    }
+    return pos;
+  }
+
+  posinset(ri: number, ci: number): number {
+    let pos = 0;
+    for (const [r, row] of this.rows.entries()) {
+      for (const [c, cell] of row.cells.entries()) {
+        if (!cell.disabled) {
+          pos++;
+          if (r === ri && c === ci) return pos;
+        }
+      }
+    }
+    return 0;
+  }
+
+  private activate(ri: number, ci: number, cell: GridCell) {
+    this.focusedRow = ri;
+    this.focusedCol = ci;
+    this.selectedRow = ri;
+    this.selectedCol = ci;
+    const v = cell.value as { l: number; c: number; h: number };
+    const oklch = `oklch(${v.l.toFixed(2)} ${v.c.toFixed(3)} ${v.h})`;
+    this.selectedColor = oklch;
+    this.announcement = `Selected: ${oklch}`;
+    this.dispatchEvent(
+      new CustomEvent('color-select', { detail: oklch, bubbles: true, composed: true }),
+    );
+    this._focusButton(ri, ci);
+  }
+
+  private _onKeydown(e: KeyboardEvent) {
+    const nav: Record<string, [number, number]> = {
+      ArrowUp: [-1, 0],
+      ArrowDown: [1, 0],
+      ArrowLeft: [0, -1],
+      ArrowRight: [0, 1],
+    };
+    if (nav[e.key]) {
+      e.preventDefault();
+      const [dr, dc] = nav[e.key];
+      const moved = this._step(dr, dc);
+      if (!moved) {
+        this.edgeToggle = !this.edgeToggle;
+        this.announcement = 'Edge of gamut' + (this.edgeToggle ? '​' : '');
+      }
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      this._jumpRowEdge(false);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      this._jumpRowEdge(true);
+    } else if (e.key === 'Enter' || e.key === ' ') {
+      const r = this.focusedRow;
+      const c = this.focusedCol;
+      const cell = this.rows[r]?.cells[c];
+      if (cell && !cell.disabled) {
+        e.preventDefault();
+        this.activate(r, c, cell);
+      }
+    }
+  }
+
+  private _step(dr: number, dc: number): boolean {
+    const numRows = this.rows.length;
+    const numCols = this.rows[0]?.cells.length ?? 0;
+    let r = this.focusedRow + dr;
+    let c = this.focusedCol + dc;
+    while (r >= 0 && r < numRows && c >= 0 && c < numCols) {
+      if (!this.rows[r].cells[c].disabled) {
+        this.focusedRow = r;
+        this.focusedCol = c;
+        this._focusButton(r, c);
+        return true;
+      }
+      r += dr;
+      c += dc;
+    }
+    return false;
+  }
+
+  private _jumpRowEdge(toEnd: boolean) {
+    const r = this.focusedRow;
+    const cells = this.rows[r]?.cells ?? [];
+    if (toEnd) {
+      for (let c = cells.length - 1; c >= 0; c--) {
+        if (!cells[c].disabled) {
+          this.focusedCol = c;
+          this._focusButton(r, c);
+          return;
+        }
+      }
+    } else {
+      for (let c = 0; c < cells.length; c++) {
+        if (!cells[c].disabled) {
+          this.focusedCol = c;
+          this._focusButton(r, c);
+          return;
+        }
+      }
+    }
+  }
+
+  private _focusButton(r: number, c: number) {
+    const btn = this.querySelector<HTMLButtonElement>(`[data-row="${r}"][data-col="${c}"]`);
+    btn?.focus();
+  }
+
+  private _findFirstInGamut(): { r: number; c: number } {
+    for (let r = 0; r < this.rows.length; r++) {
+      for (let c = 0; c < this.rows[r].cells.length; c++) {
+        if (!this.rows[r].cells[c].disabled) return { r, c };
+      }
+    }
+    return { r: 0, c: 0 };
+  }
+
+  private _parseOklch(value: string): { l: number; c: number; h: number } | null {
+    const m = value.match(/oklch\(\s*([\d.]+)\s+([\d.]+)\s+([\d.]+)\s*\)/);
+    if (!m) return null;
+    return { l: parseFloat(m[1]), c: parseFloat(m[2]), h: parseFloat(m[3]) };
+  }
+
+  private _findCellByLC(l: number, c: number): { r: number; col: number } | null {
+    for (let r = 0; r < this.rows.length; r++) {
+      for (let col = 0; col < this.rows[r].cells.length; col++) {
+        const cell = this.rows[r].cells[col];
+        if (cell.disabled || !cell.value) continue;
+        const v = cell.value as { l: number; c: number; h: number };
+        if (Math.abs(v.l - l) < 0.006 && Math.abs(v.c - c) < 0.001) return { r, col };
+      }
+    }
+    return null;
+  }
+
+  override render() {
+    return html`
+      <p id=${this.hintId} class="sr-only">
+        Arrow keys navigate · Enter or Space activates · Blank cells are outside sRGB gamut
+      </p>
+
+      <div role="group">
+        <table
+          role="grid"
+          aria-label=${this.ariaLabel || 'Tone picker'}
+          aria-describedby=${this.hintId}
+          class=${'gamut-grid' +
+            (this.hideHeaders ? ' hide-headers' : '') +
+            (this.size === 'small' ? ' size-small' : '')}
+        >
+          <thead>
+            <tr role="row">
+              <td class="corner" role="none"></td>
+              ${this.columnHeaders.map(
+                (header) => html`<th scope="col" role="columnheader" class="col-header">${header}</th>`,
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            ${this.rows.map(
+              (row, ri) => html`
+                <tr role="row">
+                  <th scope="row" role="rowheader" class="row-header">${row.rowHeader}</th>
+                  ${row.cells.map(
+                    (cell, ci) =>
+                      !cell.disabled
+                        ? html`
+                            <td role="gridcell" class="cell">
+                              <button
+                                role="radio"
+                                class="cell-btn"
+                                data-row=${ri}
+                                data-col=${ci}
+                                tabindex=${ri === this.focusedRow && ci === this.focusedCol ? 0 : -1}
+                                style="background: ${cell.background}"
+                                aria-label=${cell.label}
+                                aria-checked=${ri === this.selectedRow && ci === this.selectedCol}
+                                aria-setsize=${this.setsize}
+                                aria-posinset=${this.posinset(ri, ci)}
+                                @click=${() => this.activate(ri, ci, cell)}
+                              ></button>
+                            </td>
+                          `
+                        : html`<td role="gridcell" class="cell" aria-label="Out of gamut"></td>`,
+                  )}
+                </tr>
+              `,
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div role="status" aria-live="polite" aria-atomic="true" class="sr-only">
+        ${this.announcement}
+      </div>
+
+      <div class=${'ui' + (this.hideUi ? ' sr-only' : '')}>
+        <div class="preview">
+          ${this.selectedColor
+            ? html`
+                <span class="preview-swatch" style="background: ${this.selectedColor}" aria-hidden="true"></span>
+                <span class="preview-code">${this.selectedColor}</span>
+              `
+            : html`<span class="preview-empty">No color selected</span>`}
+        </div>
+        <p class="hint">
+          Arrow keys navigate · Enter or Space activates · Blank cells are outside sRGB gamut
+        </p>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'cc-tone-picker': CcTonePicker;
+  }
+}

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -395,9 +395,10 @@
     @if (activeNoteModal() === 'okca') {
       <p>
         A WCAG-compatible ratio (1–21) in OKLCH color space. Unlike WCAG 2, OKCA is
-        polarity-aware — light-on-dark and dark-on-light score differently. Chroma compression
-        reduces scores for saturated lighter colors (e.g. vivid pink on dark), addressing
-        common WCAG false passes. Scores are always at or below the WCAG 2 equivalent.
+        polarity-aware — light-on-dark and dark-on-light score differently, topping out at
+        20.9 and 20 respectively. Chroma compression reduces scores for saturated lighter
+        colors (e.g. vivid pink on dark), addressing common WCAG false passes. Scores are
+        always at or below the WCAG 2 equivalent — the 20.9 ceiling is what keeps that strict.
       </p>
     }
     @if (activeNoteModal() === 'apca') {

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -67,7 +67,7 @@
       letter-spacing: var(--letter-spacing-tight);
     }
 
-    app-color-contrast {
+    cc-color-contrast {
       flex-grow: 1;
       display: flex;
       align-items: stretch;
@@ -83,7 +83,7 @@
     margin-bottom: 4px;
     align-items: center;
 
-    app-color-slider {
+    cc-color-slider {
       flex-grow: 1;
     }
   }
@@ -132,7 +132,7 @@
         align-items: center;
         justify-content: space-between;
 
-        app-checkbox {
+        candor-checkbox {
           flex: 1;
         }
 
@@ -156,7 +156,7 @@
         align-items: center;
         justify-content: space-between;
 
-        app-radio {
+        candor-radio {
           flex: 1;
         }
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -509,7 +509,7 @@ export class CcApp extends LitElement {
           @open-change=${this._handleModalOpenChange}
         >
           ${this.activeNoteModal === 'okca'
-            ? html`<p>A WCAG-compatible ratio (1–21) in OKLCH color space. Unlike WCAG 2, OKCA is polarity-aware — light-on-dark and dark-on-light score differently. Chroma compression reduces scores for saturated lighter colors (e.g. vivid pink on dark), addressing common WCAG false passes. Scores are always at or below the WCAG 2 equivalent.</p>`
+            ? html`<p>A WCAG-compatible ratio (1–21) in OKLCH color space. Unlike WCAG 2, OKCA is polarity-aware — light-on-dark and dark-on-light score differently, topping out at 20.9 and 20 respectively. Chroma compression reduces scores for saturated lighter colors (e.g. vivid pink on dark), addressing common WCAG false passes. Scores are always at or below the WCAG 2 equivalent — the 20.9 ceiling is what keeps that strict.</p>`
             : ''}
           ${this.activeNoteModal === 'apca'
             ? html`<p>Gauges inclusive contrast better than WCAG 2. For more information on why, refer to the Myndex article, <a href="https://git.apcacontrast.com/documentation/WhyAPCA.html">Why APCA?</a></p>`

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,276 +1,91 @@
-import { Component, signal, computed, inject, AfterViewInit, effect, untracked } from '@angular/core';
-import { Location } from '@angular/common';
+import { LitElement, html } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { colorUtil } from './services/color-util.service';
+import type { ContrastType } from './services/color-metrics.service';
+import type { TableColorCell } from './services/color-util.service';
+import type { ResetObject } from './_components/color-slider/color-slider';
+import type { AlertMessageObj } from './_components/alert/alert';
 
-import { ContrastType } from './services/color-metrics.service';
-import { ColorUtilService } from './services/color-util.service';
-import { CopyToClipboardEvent } from './_components/copy-to-clipboard-button/copy-to-clipboard-button.component';
-import { ResetObject } from './_components/color-slider/color-slider.component';
-import { AlertMessagObj } from './_components/alert/alert.component';
-import { TableColorCell } from './_components/palette-table/palette-table.component';
+import './_candor/accordion/accordion-item';
+import './_candor/button/button';
+import './_candor/card/card';
+import './_candor/form/checkbox/checkbox';
+import './_candor/modal/modal';
+import './_candor/form/radio/radio';
+import './_candor/tooltip/tooltip';
 
-import { AlertComponent } from './_components/alert/alert.component';
-import { ColorContrastComponent } from './_components/color-contrast/color-contrast.component';
-import { ColorPickerComponent } from './_components/color-picker/color-picker.component';
-import { ColorSliderComponent } from './_components/color-slider/color-slider.component';
-import { CopyToClipboardButtonComponent } from './_components/copy-to-clipboard-button/copy-to-clipboard-button.component';
-import { MetadataComponent } from './_components/metadata/metadata.component';
-import { PaletteTableComponent } from './_components/palette-table/palette-table.component';
+import './_components/alert/alert';
+import './_components/color-contrast/color-contrast';
+import './_components/color-picker/color-picker';
+import './_components/color-slider/color-slider';
+import './_components/copy-to-clipboard-button/copy-to-clipboard-button';
+import './_components/metadata/metadata';
+import './_components/palette-table/palette-table';
 
-import { AccordionItemComponent } from './_candor/accordion/accordion-item.component';
-import { ButtonComponent } from './_candor/button/button.component';
-import { CardComponent } from './_candor/card/card.component';
-import { CheckboxComponent } from './_candor/form/checkbox/checkbox.component';
-import { ModalComponent } from './_candor/modal/modal.component';
-import { RadioComponent } from './_candor/form/radio/radio.component';
-import { TooltipComponent } from './_candor/tooltip/tooltip.component';
+import './app.scss';
 
-@Component({
-  selector: 'app-root',
-  imports: [
-    ColorContrastComponent,
-    ColorPickerComponent,
-    ColorSliderComponent,
-    CopyToClipboardButtonComponent,
-    MetadataComponent,
-    PaletteTableComponent,
-    AlertComponent,
-    AccordionItemComponent,
-    ButtonComponent,
-    CardComponent,
-    CheckboxComponent,
-    ModalComponent,
-    RadioComponent,
-    TooltipComponent,
-  ],
-  templateUrl: './app.html',
-  styleUrl: './app.scss',
-})
-export class App implements AfterViewInit {
-  cus = inject(ColorUtilService);
-  location = inject(Location);
+const NOTE_MODAL_TITLES: Record<string, string> = {
+  okca: 'OKCA',
+  apca: 'Perceptual contrast',
+  bpca: 'WCAG 2 compatible',
+  'apca object': 'Object',
+  deltaE: 'Delta E',
+  accessibility: 'Screen reader and low vision workflows',
+  wcag2: 'WCAG 2',
+  constantChroma: 'Constant chroma',
+  showGradient: 'Show Gradient',
+};
 
-  colorPickerOneSelectedColor = signal<string>('');
-  colorPickerOneComparedColor = signal<string>('');
-
-  colorPickerTwoSelectedColor = signal<string>('');
-  colorPickerTwoComparedColor = signal<string>('');
-
-  contrastType = signal<ContrastType | 'apca object'>('okca');
-
-  resetSlider: ResetObject | null = null;
-
-  constantChroma = signal<boolean>(true);
-  showGradient = signal<boolean>(true);
-
-  activeNoteModal = signal<string | null>(null);
-
-  private readonly noteModalTitles: Record<string, string> = {
-    okca: 'OKCA',
-    apca: 'Perceptual contrast',
-    bpca: 'WCAG 2 compatible',
-    'apca object': 'Object',
-    deltaE: 'Delta E',
-    accessibility: 'Screen reader and low vision workflows',
-    wcag2: 'WCAG 2',
-    constantChroma: 'Constant chroma',
-    showGradient: 'Show Gradient',
-  };
-
-  noteModalTitle = computed(() => {
-    const note = this.activeNoteModal();
-    return note ? (this.noteModalTitles[note] ?? '') : '';
-  });
-
-  currentAlertMessage = signal<AlertMessagObj>(new AlertMessagObj());
-
-  private isInitializing = signal(true);
-
-  constructor() {
-    // Update URL when state changes
-    effect(() => {
-      if (this.isInitializing()) return;
-
-      const fg = this.colorPickerOneSelectedColor();
-      const bg = this.colorPickerTwoSelectedColor();
-      const type = this.contrastType();
-      const chroma = this.constantChroma();
-      const gradient = this.showGradient();
-
-      this.updateUrl(fg, bg, type, chroma, gradient);
-    });
+@customElement('cc-app')
+export class CcApp extends LitElement {
+  override createRenderRoot(): this {
+    return this;
   }
 
-  handleColorInputInput(inputNumber: 'One' | 'Two', event: string) {
-    if (inputNumber === 'One') {
-      this.colorPickerOneSelectedColor.set(event);
-    }
+  @state() private fgColor = '';
+  @state() private bgColor = '';
+  @state() private fgComparedColor = '';
+  @state() private bgComparedColor = '';
+  @state() private contrastType: ContrastType | 'apca object' = 'okca';
+  @state() private constantChroma = true;
+  @state() private showGradient = true;
+  @state() private activeNoteModal: string | null = null;
+  @state() private currentAlertMessage: AlertMessageObj = { message: '' };
+  @state() private resetSlider: ResetObject | null = null;
 
-    if (inputNumber === 'Two') {
-      this.colorPickerTwoSelectedColor.set(event);
-    }
+  private isInitializing = true;
+
+  get noteModalTitle() {
+    const note = this.activeNoteModal;
+    return note ? (NOTE_MODAL_TITLES[note] ?? '') : '';
   }
 
-  handleSliderInputInput(inputNumber: 'One' | 'Two', event: string | null) {
-    if (inputNumber === 'One' && event) {
-      this.colorPickerOneComparedColor.set(event);
+  override connectedCallback() {
+    super.connectedCallback();
+    const hasUrlState = this._loadStateFromUrl();
+    if (!hasUrlState) {
+      this._setRandomColorPair(true);
     }
-
-    if (inputNumber === 'Two' && event) {
-      this.colorPickerTwoComparedColor.set(event);
-    }
-  }
-
-  handleCopyEvent(event: CopyToClipboardEvent) {
-    if (event.copied) {
-      this.alertUser({ message: `${event.color} copied to clipboard.` });
-    } else {
-      console.error(`color copy error.`);
-    }
-  }
-
-  handleColorPaletteButtonEvent(paletteChartNum: 'One' | 'Two', event: TableColorCell) {
-    if (paletteChartNum === 'One') {
-      this.colorPickerOneSelectedColor.set(event.color);
-    }
-
-    if (paletteChartNum === 'Two') {
-      this.colorPickerTwoSelectedColor.set(event.color);
-    }
-
-    this.alertUser({
-      message: `Color picker ${paletteChartNum} changed to ${event.color}`,
-    });
-  }
-
-  toggleConstantChroma(event: Event) {
-    const inputElement = event.target as HTMLInputElement;
-    const checked = inputElement.checked;
-
-    this.constantChroma.set(checked ? true : false);
-
-    this.resetSliders();
-  }
-
-  toggleShowGradient(event: Event) {
-    const inputElement = event.target as HTMLInputElement;
-    const checked = inputElement.checked;
-
-    this.showGradient.set(checked ? true : false);
-  }
-
-  swapColors() {
-    const getColor = (type: 'fg' | 'bg'): string | null => {
-      let color: string | null = null;
-
-      switch (type) {
-        case 'fg':
-          color = this.colorPickerOneSelectedColor();
-
-          break;
-        case 'bg':
-          color = this.colorPickerTwoSelectedColor();
-
-          break;
-
-        default:
-          break;
-      }
-
-      return color;
-    };
-
-    const oldPairing = {
-      foreground: getColor('fg'),
-      background: getColor('bg'),
-    };
-
-    const newPairing = {
-      foreground: oldPairing.background,
-      background: oldPairing.foreground,
-    };
-
-    if (newPairing.foreground && newPairing.background) {
-      this.colorPickerOneSelectedColor.set(newPairing.foreground);
-
-      this.colorPickerTwoSelectedColor.set(newPairing.background);
-
-      this.alertUser({ message: 'Swapped foreground and background colors.' });
-    } else {
-      console.error('swapping colors went badly. . .');
-    }
-  }
-
-  async setRandomColorPair(initialAppColors?: boolean) {
-    const initColorPair = await this.cus.getRandomColorPair();
-
-    const randomColorPair = await this.cus.adjustColorPairForPresentation(initColorPair);
-
     setTimeout(() => {
-      this.colorPickerOneSelectedColor.set(randomColorPair[0]);
-      this.colorPickerTwoSelectedColor.set(randomColorPair[1]);
-
-      if (!initialAppColors) {
-        this.alertUser({
-          message: `Random color pair generated: ${randomColorPair[0]}, and ${randomColorPair[1]}`,
-        });
-      }
-    }, 0);
+      this.isInitializing = false;
+    });
   }
 
-  resetSliders() {
-    this.resetSlider = { reset: true };
-
-    this.alertUser({ message: 'Resetted color sliders to initial states.' });
-  }
-
-  async matchChromas() {
-    if (this.colorPickerOneSelectedColor() && this.colorPickerTwoSelectedColor()) {
-      const matchedColors = await this.cus.matchChromas([
-        this.colorPickerOneSelectedColor(),
-        this.colorPickerTwoSelectedColor(),
-      ]);
-
-      if (matchedColors.success && matchedColors.colors && matchedColors.chroma) {
-        this.colorPickerOneSelectedColor.set(matchedColors.colors[0]);
-        this.colorPickerTwoSelectedColor.set(matchedColors.colors[1]);
-
-        this.alertUser({
-          message: `Chroma matched foreground and background colors.`,
-        });
-      } else {
-        this.alertUser({ message: 'Unable to match  chroma across colors.' });
-      }
-    }
-  }
-
-  alertUser(message: AlertMessagObj) {
-    this.currentAlertMessage.set(message);
-  }
-
-  private updateUrl(
-    fg: string,
-    bg: string,
-    type: ContrastType | 'apca object',
-    chroma: boolean,
-    gradient: boolean,
-  ): void {
+  private _updateUrl() {
+    if (this.isInitializing) return;
     const params = new URLSearchParams();
-
-    if (fg) params.set('fg', fg);
-    if (bg) params.set('bg', bg);
-    if (type !== 'okca') params.set('type', type);
-    if (!chroma) params.set('chroma', 'false');
-    if (!gradient) params.set('gradient', 'false');
-
+    if (this.fgColor) params.set('fg', this.fgColor);
+    if (this.bgColor) params.set('bg', this.bgColor);
+    if (this.contrastType !== 'okca') params.set('type', this.contrastType);
+    if (!this.constantChroma) params.set('chroma', 'false');
+    if (!this.showGradient) params.set('gradient', 'false');
     const queryString = params.toString();
     const newUrl = queryString ? `?${queryString}` : '/';
-
-    this.location.replaceState(newUrl);
+    window.history.replaceState(null, '', newUrl);
   }
 
-  private loadStateFromUrl(): boolean {
+  private _loadStateFromUrl(): boolean {
     const urlParams = new URLSearchParams(window.location.search);
-
     const fg = urlParams.get('fg');
     const bg = urlParams.get('bg');
     const type = urlParams.get('type') as ContrastType | 'apca object' | null;
@@ -279,42 +94,464 @@ export class App implements AfterViewInit {
 
     let hasUrlState = false;
 
-    if (fg) {
-      this.colorPickerOneSelectedColor.set(fg);
-      hasUrlState = true;
+    if (fg) { this.fgColor = fg; hasUrlState = true; }
+    if (bg) { this.bgColor = bg; hasUrlState = true; }
+    if (type && ['apca', 'bpca', 'apca object', 'deltaE', 'okca'].includes(type)) {
+      this.contrastType = type;
     }
-
-    if (bg) {
-      this.colorPickerTwoSelectedColor.set(bg);
-      hasUrlState = true;
-    }
-
-    if (type && (type === 'apca' || type === 'bpca' || type === 'apca object' || type === 'deltaE' || type === 'okca')) {
-      this.contrastType.set(type);
-    }
-
-    if (chroma !== null) {
-      this.constantChroma.set(chroma !== 'false');
-    }
-
-    if (gradient !== null) {
-      this.showGradient.set(gradient !== 'false');
-    }
+    if (chroma !== null) this.constantChroma = chroma !== 'false';
+    if (gradient !== null) this.showGradient = gradient !== 'false';
 
     return hasUrlState;
   }
 
-  ngAfterViewInit(): void {
-    const hasUrlState = this.loadStateFromUrl();
+  private _handleFgColorInput(event: CustomEvent) {
+    this.fgColor = event.detail;
+    this._updateUrl();
+  }
 
-    if (!hasUrlState) {
-      this.setRandomColorPair(true);
+  private _handleBgColorInput(event: CustomEvent) {
+    this.bgColor = event.detail;
+    this._updateUrl();
+  }
+
+  private _handleFgSliderInput(event: CustomEvent) {
+    if (event.detail) this.fgComparedColor = event.detail;
+  }
+
+  private _handleBgSliderInput(event: CustomEvent) {
+    if (event.detail) this.bgComparedColor = event.detail;
+  }
+
+  private _handleCopyEvent(event: CustomEvent) {
+    if (event.detail.copied) {
+      this._alertUser({ message: `${event.detail.color} copied to clipboard.` });
+    } else {
+      console.error('color copy error.');
     }
+  }
 
-    // Defer setting isInitializing to false until after the current call stack completes.
-    // This ensures the initial state is loaded before the effect starts updating the URL.
+  private _handleFgPaletteSelect(event: CustomEvent) {
+    const cell = event.detail as TableColorCell;
+    this.fgColor = cell.color;
+    this._alertUser({ message: `Color picker One changed to ${cell.color}` });
+  }
+
+  private _handleBgPaletteSelect(event: CustomEvent) {
+    const cell = event.detail as TableColorCell;
+    this.bgColor = cell.color;
+    this._alertUser({ message: `Color picker Two changed to ${cell.color}` });
+  }
+
+  private _toggleConstantChroma(event: CustomEvent) {
+    this.constantChroma = event.detail;
+    this._resetSliders();
+    this._updateUrl();
+  }
+
+  private _toggleShowGradient(event: CustomEvent) {
+    this.showGradient = event.detail;
+    this._updateUrl();
+  }
+
+  private _swapColors() {
+    if (!this.fgColor || !this.bgColor) return;
+    const tmp = this.fgColor;
+    this.fgColor = this.bgColor;
+    this.bgColor = tmp;
+    this._alertUser({ message: 'Swapped foreground and background colors.' });
+    this._updateUrl();
+  }
+
+  private async _setRandomColorPair(initialAppColors = false) {
+    const initColorPair = await colorUtil.getRandomColorPair();
+    const randomColorPair = await colorUtil.adjustColorPairForPresentation(initColorPair);
     setTimeout(() => {
-      this.isInitializing.set(false);
-    });
+      this.fgColor = randomColorPair[0];
+      this.bgColor = randomColorPair[1];
+      if (!initialAppColors) {
+        this._alertUser({
+          message: `Random color pair generated: ${randomColorPair[0]}, and ${randomColorPair[1]}`,
+        });
+      }
+      this._updateUrl();
+    }, 0);
+  }
+
+  private _resetSliders() {
+    this.resetSlider = { reset: true };
+    this._alertUser({ message: 'Resetted color sliders to initial states.' });
+  }
+
+  private async _matchChromas() {
+    if (!this.fgColor || !this.bgColor) return;
+    const matchedColors = await colorUtil.matchChromas([this.fgColor, this.bgColor]);
+    if (matchedColors.success && matchedColors.colors && matchedColors.chroma) {
+      this.fgColor = matchedColors.colors[0];
+      this.bgColor = matchedColors.colors[1];
+      this._alertUser({ message: 'Chroma matched foreground and background colors.' });
+      this._updateUrl();
+    } else {
+      this._alertUser({ message: 'Unable to match chroma across colors.' });
+    }
+  }
+
+  private _alertUser(message: AlertMessageObj) {
+    this.currentAlertMessage = { ...message };
+  }
+
+  private _handleNoteRequested(event: CustomEvent) {
+    this.activeNoteModal = event.detail;
+  }
+
+  private _handleModalOpenChange(event: CustomEvent) {
+    if (!event.detail) this.activeNoteModal = null;
+  }
+
+  private _handleContrastTypeChange(event: CustomEvent) {
+    this.contrastType = event.detail as ContrastType | 'apca object';
+    this._updateUrl();
+  }
+
+  private readonly _INFO_SVG = html`
+    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" />
+    </svg>
+  `;
+
+  override render() {
+    return html`
+      <a class="sr-only" href="#main-content">Skip to main content</a>
+      <main class="app-container" id="main-content">
+        <div class="primary-stack">
+          <candor-card class="title-and-sliders" variant="elevated" padding="none">
+            <div class="title-and-score">
+              <h1>Colors Contrast</h1>
+              <cc-color-contrast
+                colorone=${this.fgComparedColor}
+                colortwo=${this.bgComparedColor}
+                contrasttype=${this.contrastType}
+              ></cc-color-contrast>
+            </div>
+
+            <div class="title-and-sliders__body">
+              <candor-accordion-item title="How to use this app." variant="quiet">
+                <p>
+                  <span class="visual-header">Quick Start:</span>
+                  Input a foreground and background color. Use the sliders to adjust tone until you reach
+                  your target contrast, then copy each color to the clipboard.
+                </p>
+                <candor-button variant="secondary" size="small" @clicked=${() => (this.activeNoteModal = 'accessibility')}>
+                  Screen reader and low vision workflows
+                </candor-button>
+              </candor-accordion-item>
+
+              <h2 class="sr-only">Main Color Controls</h2>
+
+              <h3>Foreground Color</h3>
+
+              <div class="slide-group">
+                <candor-tooltip text="Choose foreground color" position="bottom">
+                  <cc-color-picker
+                    inputid="cp-0"
+                    inputname="Foreground Color"
+                    label="Foreground Color"
+                    comparedcolor=${this.fgComparedColor}
+                    color=${this.fgColor}
+                    @selected-color=${this._handleFgColorInput}
+                  ></cc-color-picker>
+                </candor-tooltip>
+                <cc-color-slider
+                  id="slider-0"
+                  name="Foreground Slider"
+                  label="Foreground lightness"
+                  color=${this.fgColor}
+                  ?constantchroma=${this.constantChroma}
+                  ?showgradient=${this.showGradient}
+                  .resetSlider=${this.resetSlider}
+                  @color-variant=${this._handleFgSliderInput}
+                ></cc-color-slider>
+                <candor-tooltip text="Copy foreground color" position="bottom">
+                  <cc-copy-to-clipboard-button
+                    color=${this.fgComparedColor}
+                    label="Copy foreground color"
+                    @copy-event=${this._handleCopyEvent}
+                  ></cc-copy-to-clipboard-button>
+                </candor-tooltip>
+              </div>
+
+              <candor-accordion-item title="Foreground LCH Limits" variant="subtle">
+                <div class="pallette-viz-content">
+                  <cc-palette-table
+                    color=${this.fgColor}
+                    @selected-color=${this._handleFgPaletteSelect}
+                  ></cc-palette-table>
+                </div>
+                <p class="lch-limits-intro">
+                  Variants of your foreground color within the sRGB gamut. Hue constrains your lightness
+                  and chroma options — for example, strong yellows are only possible at high lightness.
+                </p>
+              </candor-accordion-item>
+
+              <h3>Background Color</h3>
+
+              <div class="slide-group">
+                <candor-tooltip text="Choose background color" position="bottom">
+                  <cc-color-picker
+                    inputid="cp-1"
+                    inputname="Background Color"
+                    label="Background Color"
+                    comparedcolor=${this.bgComparedColor}
+                    color=${this.bgColor}
+                    @selected-color=${this._handleBgColorInput}
+                  ></cc-color-picker>
+                </candor-tooltip>
+                <cc-color-slider
+                  id="slider-1"
+                  name="Background Slider"
+                  label="Background lightness"
+                  color=${this.bgColor}
+                  ?constantchroma=${this.constantChroma}
+                  ?showgradient=${this.showGradient}
+                  .resetSlider=${this.resetSlider}
+                  @color-variant=${this._handleBgSliderInput}
+                ></cc-color-slider>
+                <candor-tooltip text="Copy background color" position="bottom">
+                  <cc-copy-to-clipboard-button
+                    color=${this.bgComparedColor}
+                    label="Copy background color"
+                    @copy-event=${this._handleCopyEvent}
+                  ></cc-copy-to-clipboard-button>
+                </candor-tooltip>
+              </div>
+
+              <candor-accordion-item title="Background LCH Limits" variant="subtle">
+                <div class="pallette-viz-content">
+                  <cc-palette-table
+                    color=${this.bgColor}
+                    @selected-color=${this._handleBgPaletteSelect}
+                  ></cc-palette-table>
+                </div>
+                <p class="lch-limits-intro">
+                  Variants of your background color within the sRGB gamut. Hue constrains your lightness
+                  and chroma options — for example, strong yellows are only possible at high lightness.
+                </p>
+              </candor-accordion-item>
+            </div>
+          </candor-card>
+
+          <candor-card class="quick-actions" variant="elevated" padding="sm">
+            <div class="quick-actions__buttons">
+              <candor-tooltip text="Swap foreground and background">
+                <candor-button
+                  variant="tertiary"
+                  size="icon"
+                  aria-label="Swap Selected Colors"
+                  ?disabled=${!this.fgColor || !this.bgColor}
+                  @clicked=${this._swapColors}
+                >
+                  <svg class="swap-colors" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+                    <g>
+                      <path d="M6.29,8.71a1,1,0,0,1,0-1.42l4-4a1,1,0,1,1,1.42,1.42L9.41,7H19a7,7,0,0,1,7,7,1,1,0,0,1-2,0,5,5,0,0,0-5-5H9.41l2.3,2.29a1,1,0,0,1,0,1.42,1,1,0,0,1-1.42,0ZM21.71,19.29a1,1,0,0,0-1.42,1.42L22.59,23H13a5,5,0,0,1-5-5,1,1,0,0,0-2,0,7,7,0,0,0,7,7h9.59l-2.3,2.29a1,1,0,0,0,0,1.42,1,1,0,0,0,1.42,0l4-4a1,1,0,0,0,0-1.42Z" />
+                    </g>
+                  </svg>
+                </candor-button>
+              </candor-tooltip>
+
+              <candor-tooltip text="Match chromas">
+                <candor-button variant="tertiary" size="icon" aria-label="Harmonize Color Pair To Same Chroma" @clicked=${this._matchChromas}>
+                  <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" xml:space="preserve">
+                    <path d="M43,39c1.66,0,3,1.34,3,3s-1.34,3-3,3H33c-1.66,0-3-1.34-3-3s1.34-3,3-3H43z" />
+                    <path d="M20,17v3h-3c-1.66,0-3,1.34-3,3s1.34,3,3,3h3v3c0,1.66,1.34,3,3,3s3-1.34,3-3v-3h3c1.66,0,3-1.34,3-3s-1.34-3-3-3h-3v-3  c0-1.66-1.34-3-3-3S20,15.34,20,17z M56,12v40c0,2.21-1.79,4-4,4H12c-2.21,0-4-1.79-4-4V12c0-2.21,1.79-4,4-4h40  C54.21,8,56,9.79,56,12z M50,50V14L14,50H50z" />
+                  </svg>
+                </candor-button>
+              </candor-tooltip>
+
+              <candor-tooltip text="Reset sliders">
+                <candor-button variant="tertiary" size="icon" aria-label="Reset Color Sliders" @clicked=${this._resetSliders}>
+                  <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                    <path d="M12,3A8.92277,8.92277,0,0,0,4.5,7.05823V5H3v5H8V8.5H5.38165A7.4775,7.4775,0,1,1,4.5,12H3a9,9,0,1,0,9-9Z" />
+                  </svg>
+                </candor-button>
+              </candor-tooltip>
+
+              <candor-tooltip text="New random pair">
+                <candor-button variant="tertiary" size="icon" aria-label="Create Random Color Pair" @clicked=${() => this._setRandomColorPair()}>
+                  <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 333 333" fill-rule="evenodd" clip-rule="evenodd">
+                    <g>
+                      <rect fill="none" stroke="currentColor" stroke-width="14" x="24" y="167" width="138" height="138" rx="26" ry="26" />
+                      <g>
+                        <g>
+                          <circle cx="118" cy="199" r="12" />
+                          <circle cx="118" cy="236" r="12" />
+                          <circle cx="118" cy="272" r="12" />
+                        </g>
+                        <g>
+                          <circle cx="67" cy="199" r="12" />
+                          <circle cx="67" cy="236" r="12" />
+                          <circle cx="67" cy="272" r="12" />
+                        </g>
+                      </g>
+                      <rect fill="none" stroke="currentColor" stroke-width="14" transform="matrix(0.707107 -0.707107 0.707107 0.707107 125.466 115.35)" width="138" height="138" rx="26" ry="26" />
+                      <circle transform="matrix(0.876112 -0.876112 0.876112 0.876112 222.904 115.349)" r="10" />
+                    </g>
+                  </svg>
+                </candor-button>
+              </candor-tooltip>
+            </div>
+          </candor-card>
+
+          <candor-card class="options" variant="elevated" padding="md">
+            <h2>Options</h2>
+
+            <candor-accordion-item title="Change how Colors Contrast works.">
+              <div>
+                <h3>Colors Contrast Value</h3>
+                <div class="radio-section">
+                  ${['okca', 'apca', 'bpca', 'apca object', 'deltaE'].map((type) => {
+                    const labels: Record<string, string> = {
+                      okca: 'OKCA',
+                      apca: 'Perceptual',
+                      bpca: 'WCAG 2 compatible',
+                      'apca object': 'Object',
+                      deltaE: 'Delta E',
+                    };
+                    const aboutLabels: Record<string, string> = {
+                      okca: 'About OKCA',
+                      apca: 'About Perceptual contrast',
+                      bpca: 'About WCAG 2 compatible',
+                      'apca object': 'About Object contrast',
+                      deltaE: 'About Delta E',
+                    };
+                    return html`
+                      <div class="radio-item">
+                        <candor-radio
+                          name="contrastType"
+                          value=${type}
+                          label=${labels[type]}
+                          ?checked=${this.contrastType === type}
+                          @changed=${this._handleContrastTypeChange}
+                        ></candor-radio>
+                        <candor-tooltip text=${aboutLabels[type]} position="left">
+                          <candor-button variant="ghost" size="icon" aria-label=${aboutLabels[type]} @clicked=${() => (this.activeNoteModal = type)}>
+                            ${this._INFO_SVG}
+                          </candor-button>
+                        </candor-tooltip>
+                      </div>
+                    `;
+                  })}
+                </div>
+              </div>
+
+              <div>
+                <h3>Color Sliders</h3>
+                <div class="checkbox-section">
+                  <div class="checkbox-item">
+                    <candor-checkbox
+                      id="option-const-chroma"
+                      name="Constant Chroma Toggle"
+                      label="Constant chroma"
+                      ?checked=${this.constantChroma}
+                      @changed=${this._toggleConstantChroma}
+                    ></candor-checkbox>
+                    <candor-tooltip text="About Constant chroma" position="left">
+                      <candor-button variant="ghost" size="icon" aria-label="About Constant chroma" @clicked=${() => (this.activeNoteModal = 'constantChroma')}>
+                        ${this._INFO_SVG}
+                      </candor-button>
+                    </candor-tooltip>
+                  </div>
+                  <div class="checkbox-item">
+                    <candor-checkbox
+                      id="option-show-grad"
+                      name="Show Gradient Toggle"
+                      label="Show Gradient"
+                      ?checked=${this.showGradient}
+                      @changed=${this._toggleShowGradient}
+                    ></candor-checkbox>
+                    <candor-tooltip text="About Show Gradient" position="left">
+                      <candor-button variant="ghost" size="icon" aria-label="About Show Gradient" @clicked=${() => (this.activeNoteModal = 'showGradient')}>
+                        ${this._INFO_SVG}
+                      </candor-button>
+                    </candor-tooltip>
+                  </div>
+                </div>
+              </div>
+            </candor-accordion-item>
+          </candor-card>
+        </div>
+
+        <candor-card class="metadata" variant="elevated" padding="md">
+          <h2 id="color-metadata">Color Metadata</h2>
+          <candor-accordion-item title="Descriptive data about your inputted colors." ?open=${true}>
+            <cc-metadata
+              colorone=${this.fgComparedColor}
+              colortwo=${this.bgComparedColor}
+              @note-requested=${this._handleNoteRequested}
+            ></cc-metadata>
+          </candor-accordion-item>
+        </candor-card>
+
+        <candor-card class="contact" variant="elevated" padding="md">
+          <div class="contact__body">
+            <h2>Contact Information and Feedback</h2>
+            <p>
+              Made by <a href="https://github.com/pawn002" aria-label="pawn002 on GitHub (external link)">pawn002</a>, who would appreciate
+              <a href="https://github.com/pawn002/color-pair-quick-iterator/issues" aria-label="bug reports and feature requests for this app on GitHub (external link)">
+                bug reports and feature requests for this app</a>
+              to help improve its Accessibility.
+            </p>
+          </div>
+        </candor-card>
+
+        <candor-modal
+          title=${this.noteModalTitle}
+          ?open=${this.activeNoteModal !== null}
+          @open-change=${this._handleModalOpenChange}
+        >
+          ${this.activeNoteModal === 'okca'
+            ? html`<p>A WCAG-compatible ratio (1–21) in OKLCH color space. Unlike WCAG 2, OKCA is polarity-aware — light-on-dark and dark-on-light score differently. Chroma compression reduces scores for saturated lighter colors (e.g. vivid pink on dark), addressing common WCAG false passes. Scores are always at or below the WCAG 2 equivalent.</p>`
+            : ''}
+          ${this.activeNoteModal === 'apca'
+            ? html`<p>Gauges inclusive contrast better than WCAG 2. For more information on why, refer to the Myndex article, <a href="https://git.apcacontrast.com/documentation/WhyAPCA.html">Why APCA?</a></p>`
+            : ''}
+          ${this.activeNoteModal === 'bpca'
+            ? html`<p>A score compatible with use for WCAG 2.x success criteria. This score meets or exceeds WCAG 2 scores to better include those with atypical vision.</p>`
+            : ''}
+          ${this.activeNoteModal === 'apca object'
+            ? html`<p>Displays the smallest pixel dimension the current contrast level supports, or <strong>!</strong> when contrast is too low for any object.</p>`
+            : ''}
+          ${this.activeNoteModal === 'deltaE'
+            ? html`<p>A measure of the perceptual difference between two colors. Unlike contrast ratios, Delta E quantifies how different two colors appear regardless of their lightness relationship. Values range from 0 (identical) upward, where higher values indicate greater perceptual difference.</p>`
+            : ''}
+          ${this.activeNoteModal === 'wcag2'
+            ? html`<p>This score is for reference only — do not use it for judging inclusive contrast.</p>`
+            : ''}
+          ${this.activeNoteModal === 'constantChroma'
+            ? html`<p>Constrains sliders to tones that preserve your input color's chroma and hue. Disable to access a wider tonal range, though some generated tones may clash with your original color. When disabled, the Show Gradient option ranges from black to white.</p>`
+            : ''}
+          ${this.activeNoteModal === 'showGradient'
+            ? html`<p>Renders a tone gradient behind the slider inputs. The gradient shows the tonal possibilities of your inputted color.</p>`
+            : ''}
+          ${this.activeNoteModal === 'accessibility'
+            ? html`
+                <p><span class="visual-header">Screen Reader Users:</span> Input a Foreground Color and a Background Color in the Main Color Controls section. Adjust colors lighter and darker using the sliders — the contrast score is announced automatically as you move them. Check full color descriptions and all contrast scores in the Color Metadata section, which is open by default.</p>
+                <p><span class="visual-header">LCH Limits Grid:</span> Each color section has a collapsible LCH Limits accordion. Inside is a tone grid — navigate it with arrow keys, activate a tone with Enter or Space. Blank cells are outside the sRGB gamut. The selected tone is announced when activated.</p>
+                <p><span class="visual-header">Low Vision Users:</span> Colors Contrast is designed to remain usable at high browser zoom — the contrast value, color inputs, sliders, and copy buttons stay visible.</p>
+                <p><span class="visual-header">Random Color Pairs:</span> The app starts with a random passing pair. Use the sliders to generate tones for each contrast level you need, or swap foreground and background for a dark-mode variant.</p>
+              `
+            : ''}
+        </candor-modal>
+
+        <div class="alert">
+          <cc-alert .alertMessage=${this.currentAlertMessage}></cc-alert>
+        </div>
+      </main>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'cc-app': CcApp;
   }
 }

--- a/src/app/services/bpca.service.ts
+++ b/src/app/services/bpca.service.ts
@@ -1,26 +1,9 @@
-import { Injectable, inject } from '@angular/core';
-import { ColorUtilService } from './color-util.service';
+import type { ColorUtilService } from './color-util.service';
 
-@Injectable({
-  providedIn: 'root',
-})
 export class BpcaService {
-  cus = inject(ColorUtilService);
+  constructor(private cus: ColorUtilService) {}
 
-  // Following Code is copied with some modification from [Bridge-PCA algo](https://github.com/Myndex/bridge-pca/blob/master/src/bridge-pca.js)
-  // Attempts to use bpca module as-is has failed because of some issue with colorparsely dependency
-
-  bridgeRatio(
-    contrastLc = 0,
-    txtY: number,
-    bgY: number,
-    ratioStr = ' to 1',
-    places = 1
-  ) {
-    // Takes the output of APCA (either a string or number)
-    // and makes it a WCAG2 ratio, returning a string '4.5 to 1'
-    // Jan 16 2022 constants
-
+  bridgeRatio(contrastLc = 0, txtY: number, bgY: number, ratioStr = ' to 1', places = 1) {
     let maxY = Math.max(txtY, bgY);
 
     const offsetA = 0.2693;
@@ -36,7 +19,7 @@ export class BpcaService {
 
     const hiTrim = 0.0785;
     const loTrim = 0.0815;
-    const trimThresh = 0.506; // #c0c0c0
+    const trimThresh = 0.506;
 
     let addTrim = loTrim + hiTrim;
 
@@ -46,33 +29,23 @@ export class BpcaService {
     }
 
     contrastLc = Math.max(0, Math.abs(contrastLc * 0.01));
-    // contrastLc = Math.max(0, Math.abs(parseFloat(contrastLc) * 0.01));
 
-    // convert Lc into a WCAG ratio
     let wcagContrast =
-      (Math.pow(contrastLc + preScale, powerShift) + offsetA) *
-        mainFactor *
-        contrastLc +
+      (Math.pow(contrastLc + preScale, powerShift) + offsetA) * mainFactor * contrastLc +
       addTrim;
 
-    // adjust WCAG ratios that are under  3 : 1, clean up near 0.
     wcagContrast =
       wcagContrast > loThresh
         ? 10.0 * wcagContrast
         : contrastLc < 0.06
-        ? 0
-        : 10.0 * wcagContrast -
-          (Math.pow(loThresh - wcagContrast + preEmph, loExp) - postDe);
+          ? 0
+          : 10.0 * wcagContrast - (Math.pow(loThresh - wcagContrast + preEmph, loExp) - postDe);
 
-    return wcagContrast.toFixed(places) + ratioStr; // + '<br>trim:' + addTrim;
+    return wcagContrast.toFixed(places) + ratioStr;
   }
 
   BPCAcontrast(txtY: number, bgY: number, places = -1) {
-    // send linear Y (luminance) for text and background.
-    // txtY and bgY must be between 0.0-1.0
-    // IMPORTANT: Do not swap, polarity is important.
-
-    const icp = [0.0, 1.1]; // input range clamp / input error check
+    const icp = [0.0, 1.1];
 
     if (
       isNaN(txtY) ||
@@ -80,16 +53,13 @@ export class BpcaService {
       Math.min(txtY, bgY) < icp[0] ||
       Math.max(txtY, bgY) > icp[1]
     ) {
-      return 0; // return zero on error
-      // return 'error'; // optional string return for error
+      return 0;
     }
-
-    //////////   BPCA 0.1.6 G - 4g Constants   ///////////////////////
 
     const normBG = 0.56,
       normTXT = 0.57,
       revTXT = 0.62,
-      revBG = 0.65; // G-4g constants for use with 2.4 exponent
+      revBG = 0.65;
 
     const blkThrs = 0.022,
       blkClmp = 1.414,
@@ -102,117 +72,58 @@ export class BpcaService {
       loClip = 0.1,
       deltaYmin = 0.0005;
 
-    //////////   SAPC LOCAL VARS   /////////////////////////////////////////
+    let SAPC = 0.0;
+    let outputContrast = 0.0;
+    let polCat = 'BoW';
 
-    let SAPC = 0.0; // For raw SAPC values
-    let outputContrast = 0.0; // For weighted final values
-    let polCat = 'BoW'; // Polarity Indicator. N normal R reverse
-
-    // TUTORIAL
-
-    // Use Y for text and BG, and soft clamp black,
-    // return 0 for very close luminances, determine
-    // polarity, and calculate SAPC raw contrast
-    // Then scale for easy to remember levels.
-
-    // Note that reverse contrast (white text on black)
-    // intentionally returns a negative number
-    // Proper polarity is important!
-
-    //////////   BLACK SOFT CLAMP   ////////////////////////////////////////
-
-    // Soft clamps Y for either color if it is near black.
     txtY = txtY > blkThrs ? txtY : txtY + Math.pow(blkThrs - txtY, blkClmp);
     bgY = bgY > blkThrs ? bgY : bgY + Math.pow(blkThrs - bgY, blkClmp);
 
-    ///// Return 0 Early for extremely low ∆Y
     if (Math.abs(bgY - txtY) < deltaYmin) {
       return 0.0;
     }
 
-    //////////   Bridge-PCA/SAPC CONTRAST - LOW CLIP (W3 LICENSE)  ///////////////
-
     if (bgY > txtY) {
-      // For normal polarity, black text on white (BoW)
-
-      // Calculate the SAPC contrast value and scale
-
       SAPC = (Math.pow(bgY, normBG) - Math.pow(txtY, normTXT)) * scaleBoW;
-
-      // Low Clip to prevent polarity reversal
       outputContrast = SAPC < loClip ? 0.0 : SAPC - loBoWoffset;
     } else {
-      // For reverse polarity, light text on dark (WoB)
-      // WoB should always return either negative value.
-      // OR the output will have R appended as string '23R'
-      // OR WoB '23 BoW' toolmaker choice so long as explained
       polCat = 'WoB';
-
       SAPC = (Math.pow(bgY, revBG) - Math.pow(txtY, revTXT)) * scaleWoB;
-
-      // this is a special offset to align with incorrect WCAG_2 math.
       let bridge = Math.max(0, txtY / bridgeWoBpivot - 1.0) * bridgeWoBfact;
-
-      // console.log(bridge + ' txtY ' + txtY + ' SAPC ' + SAPC);
-
       outputContrast = SAPC > -loClip ? 0.0 : SAPC + loWoBoffset + bridge;
     }
-
-    // return Lc (lightness contrast) as a signed numeric value
-    // Round to the nearest whole number is optional.
-    // Rounded can be a signed INT as output will be within ± 127
-    // places = -1 returns signed float, 0 returns rounded as string
 
     if (places < 0) {
       return outputContrast * 100.0;
     } else if (places == 0) {
       return (
-        Math.round(Math.abs(outputContrast) * 100.0) +
-        '<sub>' +
-        polCat +
-        '</sub>'
+        Math.round(Math.abs(outputContrast) * 100.0) + '<sub>' + polCat + '</sub>'
       );
     } else if (Number.isInteger(places)) {
       return (outputContrast * 100.0).toFixed(places);
     } else {
       throw 'Err-3';
     }
-  } // End BPCAcontrast()
+  }
 
   sRGBtoY(rgba = [0, 0, 0]) {
-    // send sRGB 8bpc (0xFFFFFF) or string
-
-    /////   Bridge-PCA 0.1.6 G - 4g - W3 Constants   ////////////////////////
-
-    const mainTRC = 2.4; // 2.4 exponent emulates actual monitor perception
-
+    const mainTRC = 2.4;
     const sRco = 0.212647813391364,
       sGco = 0.715179147533615,
-      sBco = 0.0721730390750208; // sRGB coefficients
-
-    // Derived from:
-    // xW	yW	K	xR	yR	xG	yG	xB	yB
-    // 0.312720	0.329030	6504	0.640	0.330	0.300	0.600	0.150	0.060
-
-    // linearize r, g, or b then apply coefficients
-    // and sum then return the resulting luminance
+      sBco = 0.0721730390750208;
 
     function simpleExp(chan: number) {
       return Math.pow(chan / 255.0, mainTRC);
     }
 
-    return (
-      sRco * simpleExp(rgba[0]) +
-      sGco * simpleExp(rgba[1]) +
-      sBco * simpleExp(rgba[2])
-    );
-  } // End sRGBtoY()
+    return sRco * simpleExp(rgba[0]) + sGco * simpleExp(rgba[1]) + sBco * simpleExp(rgba[2]);
+  }
 
   alphaBlend(rgbaFG = [0, 0, 0, 1.0], rgbBG = [0, 0, 0], isInt = true) {
     if (rgbaFG[3]) {
-      rgbaFG[3] = Math.max(Math.min(rgbaFG[3], 1.0), 0.0); // clamp alpha
+      rgbaFG[3] = Math.max(Math.min(rgbaFG[3], 1.0), 0.0);
       let compBlend = 1.0 - rgbaFG[3];
-      let rgbOut = [0, 0, 0]; // or just use rgbBG to retain other elements?
+      let rgbOut = [0, 0, 0];
 
       for (let i = 0; i < 3; i++) {
         rgbOut[i] = rgbBG[i] * compBlend + rgbaFG[i] * rgbaFG[3];
@@ -223,33 +134,20 @@ export class BpcaService {
     } else {
       return rgbaFG;
     }
-  } // End alphaBlend()
+  }
 
-  calcBPCA(textColor: string, bgColor: string, places = -1, isInt = true) {
-    // NOTE:  that this function required colorParsley !!
-    // let txClr = colorParsley(textColor);
-    // let bgClr = colorParsley(bgColor);
-    // let hasAlpha = txClr[3] != '' && txClr[3] < 1 ? true : false;
-    // if (hasAlpha) {
-    // txClr = this.alphaBlend(txClr, bgClr, isInt);
-    // }
-    // return this.BPCAcontrast(this.sRGBtoY(txClr), this.sRGBtoY(bgClr), places);
-
+  calcBPCA(textColor: string, bgColor: string, places = -1) {
     let bpca: string | number = NaN;
 
     let txClr = this.cus.getRgb255Array(textColor);
     let bgClr = this.cus.getRgb255Array(bgColor);
 
     if (txClr && bgClr) {
-      bpca = this.BPCAcontrast(
-        this.sRGBtoY(txClr),
-        this.sRGBtoY(bgClr),
-        places
-      );
+      bpca = this.BPCAcontrast(this.sRGBtoY(txClr), this.sRGBtoY(bgClr), places);
     } else {
-      console.warn(`issue calculating BPCA`);
+      console.warn('issue calculating BPCA');
     }
 
     return bpca;
-  } // End calcBPCA()
+  }
 }

--- a/src/app/services/color-metrics.service.spec.ts
+++ b/src/app/services/color-metrics.service.spec.ts
@@ -1,18 +1,20 @@
-import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { ColorMetricsService } from './color-metrics.service';
-import { ColorUtilService } from './color-util.service';
+import { colorUtil } from './color-util.service';
 import { BpcaService } from './bpca.service';
 
 describe('ColorMetricsService', () => {
   let service: ColorMetricsService;
-  let colorUtilService: ColorUtilService;
   let bpcaService: BpcaService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(ColorMetricsService);
-    colorUtilService = TestBed.inject(ColorUtilService);
-    bpcaService = TestBed.inject(BpcaService);
+    service = new ColorMetricsService();
+    // BpcaService is constructed internally; reach it to spy on its methods.
+    bpcaService = (service as unknown as { bpca: BpcaService }).bpca;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('should be created', () => {
@@ -32,61 +34,14 @@ describe('ColorMetricsService', () => {
       expect(typeof result).toBe('number');
     });
 
-    it('should return integer for APCA contrast', () => {
-      const result = service.getContrast('#000000', '#ffffff', 'apca');
-      expect(result).not.toBeNull();
-      expect(Number.isInteger(result!)).toBe(true);
-    });
-
-    it('should handle same colors', () => {
-      const result = service.getContrast('#808080', '#808080', 'apca');
-      expect(result).not.toBeNull();
-    });
-
-    it('should handle colored pairs', () => {
-      const result = service.getContrast('#ff5733', '#e0e0e0', 'apca');
-      expect(result).not.toBeNull();
-      expect(typeof result).toBe('number');
-    });
-
-    it('should return null when APCA calculation fails', () => {
-      spyOn(service, 'calcRawApcaContrast').and.returnValue(null);
-      const result = service.getContrast('#000000', '#ffffff', 'apca');
-      expect(result).toBeNull();
-    });
-
-    it('should handle zero contrast', () => {
-      const result = service.getContrast('#808080', '#808080', 'apca');
-      expect(result).toBe(0);
-    });
-
-    it('should return Delta E value when type is deltaE', () => {
+    it('should return Delta E when type is deltaE', () => {
       const result = service.getContrast('#000000', '#ffffff', 'deltaE');
-      expect(result).not.toBeNull();
-      expect(typeof result).toBe('number');
-    });
-
-    it('should use ColorUtilService.calcDeltaE for deltaE type', () => {
-      spyOn(colorUtilService, 'calcDeltaE').and.returnValue(100);
-      const result = service.getContrast('#000000', '#ffffff', 'deltaE');
-      expect(colorUtilService.calcDeltaE).toHaveBeenCalledWith('#000000', '#ffffff');
-      expect(result).toBe(100);
-    });
-
-    it('should handle deltaE for identical colors', () => {
-      const result = service.getContrast('#808080', '#808080', 'deltaE');
-      expect(result).not.toBeNull();
-      expect(result).toBe(0);
-    });
-
-    it('should handle deltaE for colored pairs', () => {
-      const result = service.getContrast('#ff5733', '#e0e0e0', 'deltaE');
       expect(result).not.toBeNull();
       expect(typeof result).toBe('number');
     });
 
     it('should return null when calcDeltaE returns null', () => {
-      spyOn(colorUtilService, 'calcDeltaE').and.returnValue(null);
+      vi.spyOn(colorUtil, 'calcDeltaE').mockReturnValue(null);
       const result = service.getContrast('#000000', '#ffffff', 'deltaE');
       expect(result).toBeNull();
     });
@@ -97,11 +52,49 @@ describe('ColorMetricsService', () => {
       expect(typeof result).toBe('number');
     });
 
-    it('should return ~21 for black on white with okca', () => {
-      const result = service.getContrast('#000000', '#ffffff', 'okca');
-      expect(result).not.toBeNull();
-      expect(result!).toBeGreaterThanOrEqual(20);
-      expect(result!).toBeLessThanOrEqual(21);
+    // OKCA v2 anchors. The scale is nominally 1–21, but light-on-dark is capped
+    // at LOD_CAP = 20.9 so every score sits strictly below the WCAG equivalent.
+    // Dark-on-light is uncapped and tops out at 20.0.
+    it('should return the OKCA v2 dark-on-light ceiling for black on white', () => {
+      expect(service.getContrast('#000000', '#ffffff', 'okca')).toBe(20);
+    });
+
+    it('should return the OKCA v2 light-on-dark cap (20.9) for white on black', () => {
+      expect(service.getContrast('#ffffff', '#000000', 'okca')).toBe(20.9);
+    });
+
+    it('should never exceed the light-on-dark cap of 20.9', () => {
+      const pairs: Array<[string, string]> = [
+        ['#ffffff', '#000000'],
+        ['#ffff00', '#000000'],
+        ['#00ffff', '#0a0a0a'],
+        ['#000000', '#ffffff'],
+      ];
+
+      pairs.forEach(([fg, bg]) => {
+        const result = service.getContrast(fg, bg, 'okca');
+        expect(result).not.toBeNull();
+        expect(result!).toBeLessThanOrEqual(20.9);
+      });
+    });
+
+    it('should score the WCAG AA boundary grey at the v2 anchor', () => {
+      // POL_K recalibration in v2.0.0 moved this anchor from 3.5 to 3.9.
+      expect(service.getContrast('#ffffff', '#767676', 'okca')).toBe(3.9);
+      expect(service.getContrast('#767676', '#ffffff', 'okca')).toBe(3.7);
+    });
+
+    it('should still catch saturated chromatic false passes', () => {
+      // WCAG rates hot pink on near-black 6.6:1; OKCA keeps it below AA.
+      const result = service.getContrast('#ff69b4', '#1a1a1a', 'okca');
+      expect(result).toBe(3.6);
+      expect(result!).toBeLessThan(4.5);
+    });
+
+    it('should be polarity-aware', () => {
+      const lightOnDark = service.getContrast('#ffffff', '#000000', 'okca');
+      const darkOnLight = service.getContrast('#000000', '#ffffff', 'okca');
+      expect(lightOnDark).not.toBe(darkOnLight);
     });
 
     it('should return 1 for identical colors with okca', () => {
@@ -115,7 +108,7 @@ describe('ColorMetricsService', () => {
       expect(result).not.toBeNull();
       expect(typeof result).toBe('number');
       expect(result!).toBeGreaterThanOrEqual(1);
-      expect(result!).toBeLessThanOrEqual(21);
+      expect(result!).toBeLessThanOrEqual(20.9);
     });
 
     it('should handle named colors with okca', () => {
@@ -127,6 +120,34 @@ describe('ColorMetricsService', () => {
     it('should return null for invalid colors with okca', () => {
       const result = service.getContrast('not-a-color', '#ffffff', 'okca');
       expect(result).toBeNull();
+    });
+  });
+
+  describe('OKCA is never more permissive than WCAG', () => {
+    // The load-bearing guarantee of the algorithm: OKCA <= WCAG for every sRGB
+    // pair. Upstream proves this across the gamut; this spot-checks that the
+    // version we ship actually holds it at the app's call site.
+    const pairs: Array<[string, string]> = [
+      ['#000000', '#ffffff'],
+      ['#ffffff', '#000000'],
+      ['#ffffff', '#767676'],
+      ['#ff69b4', '#1a1a1a'],
+      ['#ff5733', '#e0e0e0'],
+      ['#333333', '#cccccc'],
+      ['#0000ff', '#ffffff'],
+      ['#00ff00', '#000000'],
+    ];
+
+    pairs.forEach(([fg, bg]) => {
+      it(`should score ${fg} on ${bg} at or below WCAG`, () => {
+        const okca = service.getContrast(fg, bg, 'okca');
+        const wcag = colorUtil.calcWcag2(fg, bg);
+
+        expect(okca).not.toBeNull();
+        expect(wcag).not.toBeNull();
+        // OKCA rounds to 1dp, so allow the rounding step as tolerance.
+        expect(okca!).toBeLessThanOrEqual(wcag! + 0.05);
+      });
     });
   });
 
@@ -154,12 +175,6 @@ describe('ColorMetricsService', () => {
       expect(result).toBe(0);
     });
 
-    it('should handle maximum contrast', () => {
-      const result = service.calcRawApcaContrast('#000000', '#ffffff');
-      expect(result).not.toBeNull();
-      expect(Math.abs(result!)).toBeGreaterThan(100);
-    });
-
     it('should handle low contrast', () => {
       const result = service.calcRawApcaContrast('#808080', '#888888');
       expect(result).not.toBeNull();
@@ -172,16 +187,6 @@ describe('ColorMetricsService', () => {
       expect(result1).not.toBeNull();
       expect(result2).not.toBeNull();
       expect(Math.sign(result1!)).not.toBe(Math.sign(result2!));
-    });
-
-    it('should handle red and white', () => {
-      const result = service.calcRawApcaContrast('#ff0000', '#ffffff');
-      expect(result).not.toBeNull();
-    });
-
-    it('should handle blue and white', () => {
-      const result = service.calcRawApcaContrast('#0000ff', '#ffffff');
-      expect(result).not.toBeNull();
     });
   });
 
@@ -204,22 +209,17 @@ describe('ColorMetricsService', () => {
       expect(typeof result).toBe('number');
     });
 
-    it('should handle identical colors', () => {
-      const result = service.calcRawBpcaContrast('#808080', '#808080');
-      expect(result).not.toBeNaN();
-    });
-
     it('should return NaN when RGB conversion fails', () => {
-      spyOn(colorUtilService, 'getRgb255Array').and.returnValue(null);
+      vi.spyOn(colorUtil, 'getRgb255Array').mockReturnValue(null);
       const result = service.calcRawBpcaContrast('#000000', '#ffffff');
       expect(result).toBeNaN();
     });
 
     it('should use BpcaService for calculation', () => {
-      spyOn(bpcaService, 'calcBPCA').and.returnValue(60);
-      spyOn(colorUtilService, 'getRgb255Array').and.returnValue([255, 255, 255]);
-      spyOn(bpcaService, 'sRGBtoY').and.returnValue(1.0);
-      spyOn(bpcaService, 'bridgeRatio').and.returnValue('4.5');
+      vi.spyOn(bpcaService, 'calcBPCA').mockReturnValue(60);
+      vi.spyOn(colorUtil, 'getRgb255Array').mockReturnValue([255, 255, 255]);
+      vi.spyOn(bpcaService, 'sRGBtoY').mockReturnValue(1.0);
+      vi.spyOn(bpcaService, 'bridgeRatio').mockReturnValue('4.5');
 
       const result = service.calcRawBpcaContrast('#000000', '#ffffff');
 
@@ -251,19 +251,6 @@ describe('ColorMetricsService', () => {
       expect(apcaResult).not.toBe(bpcaResult);
     });
 
-    it('should produce different results for APCA vs BPCA vs Delta E', () => {
-      const apcaResult = service.getContrast('#000000', '#ffffff', 'apca');
-      const bpcaResult = service.getContrast('#000000', '#ffffff', 'bpca');
-      const deltaEResult = service.getContrast('#000000', '#ffffff', 'deltaE');
-
-      expect(apcaResult).not.toBeNull();
-      expect(bpcaResult).not.toBeNull();
-      expect(deltaEResult).not.toBeNull();
-      expect(apcaResult).not.toBe(bpcaResult);
-      expect(apcaResult).not.toBe(deltaEResult);
-      expect(bpcaResult).not.toBe(deltaEResult);
-    });
-
     it('should produce different results for OKCA vs APCA', () => {
       const okcaResult = service.getContrast('#000000', '#ffffff', 'okca');
       const apcaResult = service.getContrast('#000000', '#ffffff', 'apca');
@@ -283,14 +270,10 @@ describe('ColorMetricsService', () => {
       ];
 
       testPairs.forEach((pair) => {
-        const apcaResult = service.getContrast(pair[0], pair[1], 'apca');
-        const bpcaResult = service.getContrast(pair[0], pair[1], 'bpca');
-        const deltaEResult = service.getContrast(pair[0], pair[1], 'deltaE');
-        const okcaResult = service.getContrast(pair[0], pair[1], 'okca');
-        expect(apcaResult).not.toBeNull();
-        expect(bpcaResult).not.toBeNull();
-        expect(deltaEResult).not.toBeNull();
-        expect(okcaResult).not.toBeNull();
+        expect(service.getContrast(pair[0], pair[1], 'apca')).not.toBeNull();
+        expect(service.getContrast(pair[0], pair[1], 'bpca')).not.toBeNull();
+        expect(service.getContrast(pair[0], pair[1], 'deltaE')).not.toBeNull();
+        expect(service.getContrast(pair[0], pair[1], 'okca')).not.toBeNull();
       });
     });
 
@@ -313,8 +296,8 @@ describe('ColorMetricsService', () => {
       const colors = ['#ff0000', '#00ff00', '#0000ff', '#ffff00', '#ff00ff', '#00ffff'];
 
       colors.forEach((color) => {
-        const result = service.getContrast(color, '#ffffff', 'apca');
-        expect(result).not.toBeNull();
+        expect(service.getContrast(color, '#ffffff', 'apca')).not.toBeNull();
+        expect(service.getContrast(color, '#ffffff', 'okca')).not.toBeNull();
       });
     });
 

--- a/src/app/services/color-metrics.service.ts
+++ b/src/app/services/color-metrics.service.ts
@@ -1,44 +1,25 @@
-import { Injectable, inject } from '@angular/core';
-
-import { calcAPCA, sRGBtoY } from 'apca-w3';
+import { calcAPCA } from 'apca-w3';
 import { contrast as okcaContrast } from '@pawn002/okca';
-
-import { scaleLinear } from 'd3';
-
-import { ColorUtilService } from './color-util.service';
+import { colorUtil } from './color-util.service';
 import { BpcaService } from './bpca.service';
 
-export interface NumberKeyLookup {
-  [key: number]: number;
-}
-
 export type ContrastType = 'apca' | 'bpca' | 'deltaE' | 'okca';
-@Injectable({
-  providedIn: 'root',
-})
+
 export class ColorMetricsService {
-  cus = inject(ColorUtilService);
-  bpca = inject(BpcaService);
+  private bpca: BpcaService;
 
-  apcaToWcagLookup: NumberKeyLookup = {};
-  apcaToWcagLookupAlt: NumberKeyLookup = {};
+  constructor() {
+    this.bpca = new BpcaService(colorUtil);
+  }
 
-  getContrast(
-    colorOne: string,
-    colorTwo: string,
-    contrastType: ContrastType
-  ): number | null {
-    let score: number | null = null;
-
+  getContrast(colorOne: string, colorTwo: string, contrastType: ContrastType): number | null {
     if (contrastType === 'deltaE') {
-      // Handle Delta E separately as it doesn't use APCA
-      score = this.cus.calcDeltaE(colorOne, colorTwo);
-      return score;
+      return colorUtil.calcDeltaE(colorOne, colorTwo);
     }
 
     if (contrastType === 'okca') {
-      const hexOne = this.cus.toHexString(colorOne);
-      const hexTwo = this.cus.toHexString(colorTwo);
+      const hexOne = colorUtil.toHexString(colorOne);
+      const hexTwo = colorUtil.toHexString(colorTwo);
       if (!hexOne || !hexTwo) return null;
       return okcaContrast(hexOne, hexTwo);
     }
@@ -47,47 +28,40 @@ export class ColorMetricsService {
 
     if (contrast || contrast === 0) {
       if (contrastType === 'apca') {
-        const roundedContrast = contrast.toFixed(0);
-
-        score = parseInt(roundedContrast);
+        return parseInt(contrast.toFixed(0));
       }
 
       if (contrastType === 'bpca') {
-        const bpcaScore = this.calcRawBpcaContrast(colorOne, colorTwo);
-
-        score = bpcaScore;
+        return this.calcRawBpcaContrast(colorOne, colorTwo);
       }
     } else {
-      console.error(`Raw APCA contrast was not calculable`);
+      console.error('Raw APCA contrast was not calculable');
     }
 
-    return score;
+    return null;
   }
 
   calcRawApcaContrast(colorOne: string, colorTwo: string): number | null {
-    let score: number | null = null;
-
-    score = calcAPCA(colorOne, colorTwo);
-
-    return score;
+    return calcAPCA(colorOne, colorTwo);
   }
 
   calcRawBpcaContrast(colorOne: string, colorTwo: string) {
     let wcag: number = NaN;
 
     const lc = this.bpca.calcBPCA(colorOne, colorTwo) as number;
-    const colorOneArray255 = this.cus.getRgb255Array(colorOne);
-    const colorTwoArray255 = this.cus.getRgb255Array(colorTwo);
+    const colorOneArray255 = colorUtil.getRgb255Array(colorOne);
+    const colorTwoArray255 = colorUtil.getRgb255Array(colorTwo);
 
     if (colorOneArray255 && colorTwoArray255) {
       const colorOneY = this.bpca.sRGBtoY(colorOneArray255);
       const colorTwoY = this.bpca.sRGBtoY(colorTwoArray255);
-
       wcag = parseFloat(this.bpca.bridgeRatio(lc, colorOneY, colorTwoY, ''));
     } else {
-      console.warn(`trouble calculating raw BPCA`);
+      console.warn('trouble calculating raw BPCA');
     }
 
     return wcag;
   }
 }
+
+export const colorMetrics = new ColorMetricsService();

--- a/src/app/services/color-util.service.ts
+++ b/src/app/services/color-util.service.ts
@@ -1,12 +1,9 @@
-import { Injectable } from '@angular/core';
 import Color from 'colorjs.io';
 import { ColorConstructor } from 'colorjs.io';
 import { scaleLinear } from 'd3';
 import { random } from 'lodash-es';
-import { TableColorCell, TableData } from '../_components/palette-table/palette-table.component';
 
 export type ColorPair = [string, string];
-
 export type ColorCoordArray = [number, number, number];
 
 export class ChromaMatchObject {
@@ -21,8 +18,6 @@ export interface MinMaxLightObject {
   lightMax: number;
 }
 
-// export type ColorVariant = [number, number, number];
-
 export interface ColorMetaObj {
   lightness: number | string;
   chroma: number | string;
@@ -30,13 +25,22 @@ export interface ColorMetaObj {
   saturation: number | string;
 }
 
-@Injectable({
-  providedIn: 'root',
-})
+export interface TableColorCell {
+  color: string;
+  lightness: number;
+  chroma: number;
+  hue: number;
+  deltaE: number;
+  deltaLightness: number;
+  deltaChroma: number;
+}
+
+export type TableRow = Array<TableColorCell>;
+export type TableData = Array<TableRow>;
+
 export class ColorUtilService {
   parseColor(color: string): ColorConstructor | null {
     let parsedColor: ColorConstructor | null = null;
-
     try {
       parsedColor = Color.parse(color);
     } catch (error) {
@@ -49,7 +53,6 @@ export class ColorUtilService {
     const parsed = this.parseColor(color);
     if (!parsed) return null;
     const hex = new Color(parsed).to('srgb').toString({ format: 'hex' });
-    // colorjs.io may return 3-digit shorthand (#fff) — expand to 6-digit for okca compatibility
     return hex.replace(/^#([0-9a-f])([0-9a-f])([0-9a-f])$/i, '#$1$1$2$2$3$3');
   }
 
@@ -61,14 +64,12 @@ export class ColorUtilService {
     return `oklch(${l.toFixed(2)} ${c.toFixed(3)} ${(h || 0).toFixed(1)})`;
   }
 
-  getRgb255Array(color: string) {
+  getRgb255Array(color: string): [number, number, number] | null {
     const colorObj = this.parseColor(color);
-
     let array255: [number, number, number] | null = null;
 
     if (colorObj) {
       const colorCoordsDecimal = colorObj.coords;
-
       array255 = [
         Math.round(colorCoordsDecimal[0] * 255),
         Math.round(colorCoordsDecimal[1] * 255),
@@ -83,7 +84,6 @@ export class ColorUtilService {
 
   createSrgbColor(color: string, lightness: number): string | null {
     let srgbColor: string | null = null;
-
     const parsedColor = this.parseColor(color);
 
     if (parsedColor) {
@@ -92,14 +92,8 @@ export class ColorUtilService {
       const originalHue = oklchColor.coords[2];
 
       const targetColor = new Color('oklch', [lightness, originalChroma, originalHue]);
-
-      const tColorInSrgbGamut = targetColor.toGamut({
-        space: 'srgb',
-        method: 'oklch.c',
-      });
-
+      const tColorInSrgbGamut = targetColor.toGamut({ space: 'srgb', method: 'oklch.c' });
       const targetColorAsRgbColor = tColorInSrgbGamut.to('srgb');
-
       srgbColor = targetColorAsRgbColor.toString({ format: 'hex' });
     }
 
@@ -111,7 +105,6 @@ export class ColorUtilService {
       try {
         const colorObject = new Color('oklch', oklchColorCoord);
         const variantInGamut = colorObject.inGamut('srgb');
-
         resolve(variantInGamut);
       } catch (error) {
         reject(error);
@@ -121,7 +114,6 @@ export class ColorUtilService {
 
   createVariants(color: string): Array<ColorCoordArray> | null {
     let variantCollection: Array<ColorCoordArray> | null = null;
-
     const parsedColor = this.parseColor(color);
 
     if (parsedColor) {
@@ -130,54 +122,45 @@ export class ColorUtilService {
       const colorChroma = lchCooords[1];
       const colorHue = lchCooords[2];
 
-      // 1) create enough steps of lightness
       const lightnessSteps = 1000;
       const lightMax = 1;
       const lightMin = 0;
       const lightInterval = (lightMax - lightMin) / lightnessSteps;
 
-      // 2) create all variants of color using constant chroma and hue.
       variantCollection = [];
 
-      // 2a) this actually creates `lightnessSteps + 1` variants as initial variant has to start at zero.
       for (let i = 0; i <= lightnessSteps; i++) {
         const variantTargetLight = i * lightInterval;
         const variant: ColorCoordArray = [variantTargetLight, colorChroma, colorHue];
-
         variantCollection.push(variant);
       }
     } else {
-      console.error(`unable to parse color`);
+      console.error('unable to parse color');
     }
 
     return variantCollection;
   }
 
-  filterOutOfGamutVariants(
-    variants: Array<ColorCoordArray> | null,
-  ): Promise<Array<ColorCoordArray>> {
+  filterOutOfGamutVariants(variants: Array<ColorCoordArray> | null): Promise<Array<ColorCoordArray>> {
     return new Promise(async (resolve, reject) => {
       if (!variants) {
-        reject(`no variants`);
+        reject('no variants');
       } else {
         let filteringComplete: boolean = false;
-
         const filtered = [];
 
         for (let i = 0; i < variants.length; i++) {
           const curVariant = variants[i];
-
           if (await this.isInSrgbGamut(curVariant)) {
             filtered.push(curVariant);
           }
-
           if (i === variants.length - 1) filteringComplete = true;
         }
 
         if (filteringComplete) {
           resolve(filtered);
         } else {
-          reject(`error`);
+          reject('error');
         }
       }
     });
@@ -187,14 +170,11 @@ export class ColorUtilService {
     let returnedObject: MinMaxLightObject | null = null;
 
     const initVariantCollection = this.createVariants(color);
-
     const variantCollection = await this.filterOutOfGamutVariants(initVariantCollection);
-
     const parsedColor = this.parseColor(color);
 
     if (parsedColor && variantCollection.length) {
       const oklchColor = Color.to(parsedColor, 'oklch');
-
       const lchCooords = oklchColor.coords;
 
       const oklchLightCoordIndex = 0;
@@ -211,10 +191,9 @@ export class ColorUtilService {
       };
     } else {
       if (!parsedColor) {
-        console.error(`unable to parse color`);
+        console.error('unable to parse color');
       } else {
         const oklchColor = Color.to(parsedColor, 'oklch');
-
         const lchCooords = oklchColor.coords;
         returnedObject = {
           originalCoords: lchCooords,
@@ -230,10 +209,7 @@ export class ColorUtilService {
   async getRandomColorPair(): Promise<ColorPair> {
     let pair: ColorPair = ['black', 'white'];
 
-    // ref: oklch.com
-    // const targetChroma = 0.11;
     const targetChroma = random(0.11, 0.34, true);
-
     const colorOneLight = random(0.25, 0.26, true);
     const colorOneHue = random(0, 360, true);
     const colorTwoLight = random(0.94, 0.95, true);
@@ -250,15 +226,12 @@ export class ColorUtilService {
       .toString({ format: 'hex' });
 
     const initPair: ColorPair = [colorOne, colorTwo];
-
     const chromaMatchedPair = await this.matchChromas(initPair);
-
     pair = chromaMatchedPair.colors ? chromaMatchedPair.colors : pair;
 
     return pair;
   }
 
-  // This function only adjust the first color of the pair.
   async adjustColorPairForPresentation(pair: ColorPair): Promise<ColorPair> {
     let returnedPair: ColorPair = ['black', 'white'];
 
@@ -266,7 +239,6 @@ export class ColorUtilService {
     const colortwo = pair[1];
 
     const parsedColorOne = this.parseColor(colorOne);
-
     const colorOneMinMaxLightObj = await this.getMinMaxLight(colorOne);
 
     if (parsedColorOne && colorOneMinMaxLightObj) {
@@ -321,49 +293,41 @@ export class ColorUtilService {
 
       if (colorOneCandInGamut && !colorTwoCandInGamut) {
         pair.success = true;
-
         pair.colors = [
           new Color('oklch', colorOneCandCoords).to('srgb').toString({ format: 'hex' }),
           colorpair[1],
         ];
-
         pair.chroma = colorOneCandCoords[1];
       }
 
       if (!colorOneCandInGamut && colorTwoCandInGamut) {
         pair.success = true;
-
         pair.colors = [
           colorpair[0],
           new Color('oklch', colorTwoCandCoords).to('srgb').toString({ format: 'hex' }),
         ];
-
         pair.chroma = colorTwoCandCoords[1];
       }
 
       if (colorOneCandInGamut && colorTwoCandInGamut) {
         if (colorOneCandCoords[1] > colorTwoCandCoords[1]) {
           pair.success = true;
-
           pair.colors = [
             new Color('oklch', colorOneCandCoords).to('srgb').toString({ format: 'hex' }),
             colorpair[1],
           ];
-
           pair.chroma = colorTwoCandCoords[1];
         } else {
           pair.success = true;
-
           pair.colors = [
             colorpair[0],
             new Color('oklch', colorTwoCandCoords).to('srgb').toString({ format: 'hex' }),
           ];
-
           pair.chroma = colorTwoCandCoords[1];
         }
       }
     } else {
-      console.error("color parsing didn't work out. ");
+      console.error("color parsing didn't work out.");
     }
 
     return pair;
@@ -378,12 +342,7 @@ export class ColorUtilService {
     if (colorOneParsed && colorTwoParsed) {
       const colorOneObj = new Color('srgb', colorOneParsed.coords);
       const colorTwoObj = new Color('srgb', colorTwoParsed.coords);
-
       const rawDelta = colorOneObj.deltaE2000(colorTwoObj);
-
-      // const fixedDelta = rawDelta.toFixed(2);
-
-      // delta = parseFloat(fixedDelta);
       delta = Math.round(rawDelta);
     }
 
@@ -399,12 +358,8 @@ export class ColorUtilService {
     if (colorOneParsed && colorTwoParsed) {
       const colorOneObj = new Color('srgb', colorOneParsed.coords);
       const colorTwoObj = new Color('srgb', colorTwoParsed.coords);
-
       const rawWcag21 = colorOneObj.contrast(colorTwoObj, 'WCAG21');
-
-      const fixedDelta = rawWcag21.toFixed(1);
-
-      wcag21 = parseFloat(fixedDelta);
+      wcag21 = parseFloat(rawWcag21.toFixed(1));
     }
 
     return wcag21;
@@ -412,12 +367,10 @@ export class ColorUtilService {
 
   getColorMeta(color: string): ColorMetaObj | null {
     let meta: ColorMetaObj | null = null;
-
     const parsedColor = this.parseColor(color);
 
     if (parsedColor) {
       const lchColor = Color.to(parsedColor, 'oklch');
-
       meta = {
         lightness: lchColor.coords[0].toFixed(2),
         chroma: lchColor.coords[1].toFixed(2),
@@ -433,47 +386,20 @@ export class ColorUtilService {
     let dimension: number = NaN;
 
     const absApca = Math.abs(apca);
-
     const pixels = [1, 1.5, 2, 3, 4, 6, 8, 10, 15];
     const apcaScores = [90, 75, 60, 50, 45, 30, 25, 20, 15];
     const minLookup = scaleLinear(pixels).domain(apcaScores);
-
     const initSize = minLookup(absApca).toFixed(2);
 
     dimension = parseFloat(initSize);
 
-    if (dimension > 15) {
-      dimension = 15;
-    }
-
-    if (absApca >= 100) {
-      dimension = 0.25;
-    }
-
-    if (absApca < 15) {
-      dimension = NaN;
-    }
+    if (dimension > 15) dimension = 15;
+    if (absApca >= 100) dimension = 0.25;
+    if (absApca < 15) dimension = NaN;
 
     return dimension;
   }
 
-  /**
-   * Generate a variant grid where every adjacent cell differs by at least
-   * `minDelta` Delta E 2000 from its neighbors on both the lightness and
-   * chroma axes.  The grid self-sizes based on the color's sRGB gamut
-   * boundaries — no fixed step counts.
-   *
-   * Algorithm:
-   *  1. Walk chroma outward from the base color at the base lightness.
-   *     Accept a new chroma level only when deltaE >= minDelta from the
-   *     previously accepted level.
-   *  2. At each accepted chroma, walk lightness outward from the base
-   *     independently — so each chroma column explores the full gamut
-   *     range available at that chroma.
-   *  3. Only in-gamut (sRGB) cells are emitted.
-   *  4. Columns (chroma walks) are assembled into rows (by lightness)
-   *     to produce a jagged table ordered light-to-dark.
-   */
   generateAdaptiveVariants(color: string, minDelta: number = 11): TableData {
     const parsedColor = this.parseColor(color);
     if (!parsedColor) throw new Error(`Could not parse color: ${color}`);
@@ -486,11 +412,8 @@ export class ColorUtilService {
     const L_STEP = 0.005;
     const C_STEP = 0.005;
 
-    // --- Build accepted chroma levels (once, at base lightness) ---
     const chromaLevels = this.walkAxis(baseL, baseC, baseH, minDelta, C_STEP, 0, 0.4, 'chroma');
 
-    // --- At each chroma, build accepted lightness levels independently ---
-    // columns[i] = array of cells for chromaLevels[i], ordered low-L to high-L
     const columns: TableColorCell[][] = [];
 
     for (const targetC of chromaLevels) {
@@ -517,42 +440,26 @@ export class ColorUtilService {
         });
       }
 
-      if (col.length > 0) {
-        columns.push(col);
-      }
+      if (col.length > 0) columns.push(col);
     }
 
-    // --- Sort each column light-to-dark (descending lightness) ---
     for (const col of columns) {
       col.sort((a, b) => b.lightness - a.lightness);
     }
 
-    // --- Transpose columns into rows by index ---
-    // Row r = the r-th cell from each column that has at least r+1 cells.
-    // This keeps each visual column at constant chroma with lightness
-    // decreasing top-to-bottom.
     const maxHeight = Math.max(...columns.map((c) => c.length));
     const grid: TableData = [];
     for (let r = 0; r < maxHeight; r++) {
       const row: TableColorCell[] = [];
       for (const col of columns) {
-        if (r < col.length) {
-          row.push(col[r]);
-        }
+        if (r < col.length) row.push(col[r]);
       }
-      if (row.length > 0) {
-        grid.push(row);
-      }
+      if (row.length > 0) grid.push(row);
     }
 
     return grid;
   }
 
-  /**
-   * Walk an OKLCH axis outward from a base value in both directions,
-   * accepting positions only when they are >= minDelta from the
-   * previously accepted position.
-   */
   private walkAxis(
     baseL: number,
     baseC: number,
@@ -575,7 +482,6 @@ export class ColorUtilService {
     const baseVal = axis === 'lightness' ? baseL : baseC;
     const accepted: number[] = [baseVal];
 
-    // Walk upward
     let prevHex = makeHex(getLVal(baseVal), getCVal(baseVal));
     let pos = baseVal + step;
     while (pos <= max) {
@@ -587,16 +493,13 @@ export class ColorUtilService {
           prevHex = hex;
         }
       } else if (hex && !prevHex) {
-        // Re-entered gamut
         prevHex = hex;
       } else if (!hex && prevHex) {
-        // Left gamut, stop
         break;
       }
       pos += step;
     }
 
-    // Walk downward
     prevHex = makeHex(getLVal(baseVal), getCVal(baseVal));
     pos = baseVal - step;
     while (pos >= min) {
@@ -617,6 +520,6 @@ export class ColorUtilService {
 
     return accepted;
   }
-
-  constructor() {}
 }
+
+export const colorUtil = new ColorUtilService();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,10 @@
-import { bootstrapApplication } from '@angular/platform-browser';
-import { appConfig } from './app/app.config';
-import { App } from './app/app';
+import '@candor-design/tokens/tokens/candor-tokens.css';
+import '@fontsource/atkinson-hyperlegible/400.css';
+import '@fontsource/atkinson-hyperlegible/400-italic.css';
+import '@fontsource/atkinson-hyperlegible/700.css';
+import '@fontsource/atkinson-hyperlegible/700-italic.css';
+import '@fontsource-variable/roboto-flex';
+import '@fontsource-variable/roboto-mono';
+import './styles.scss';
 
-bootstrapApplication(App, appConfig)
-  .catch((err) => console.error(err));
+import './app/app';

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,13 +1,3 @@
-/* You can add global styles to this file, and also import other style files */
-
-/* Candor Design System fonts */
-@import url('@fontsource/atkinson-hyperlegible/400.css');
-@import url('@fontsource/atkinson-hyperlegible/400-italic.css');
-@import url('@fontsource/atkinson-hyperlegible/700.css');
-@import url('@fontsource/atkinson-hyperlegible/700-italic.css');
-@import url('@fontsource-variable/roboto-flex/index.css');
-@import url('@fontsource-variable/roboto-mono/index.css');
-
 /* App layout tokens (no Candor equivalent) */
 :root {
   --min-hit-dimension-aaa: 2.75rem;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,3 +1,29 @@
+/* Custom element display defaults (custom elements are inline by default) */
+cc-app,
+cc-alert,
+cc-color-contrast,
+cc-color-picker,
+cc-color-slider,
+cc-copy-to-clipboard-button,
+cc-metadata,
+cc-palette-table,
+cc-tone-picker,
+candor-accordion-item,
+candor-button,
+candor-card,
+candor-checkbox,
+candor-modal,
+candor-radio,
+candor-table,
+candor-toast {
+  display: block;
+}
+
+candor-tooltip {
+  display: inline-block;
+  position: relative;
+}
+
 /* App layout tokens (no Candor equivalent) */
 :root {
   --min-hit-dimension-aaa: 2.75rem;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,34 +1,51 @@
-/* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
-/* To learn more about Angular compiler options: https://angular.dev/reference/configs/angular-compiler-options. */
 {
-  "compileOnSave": false,
   "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "strict": true,
     "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "skipLibCheck": true,
-    "isolatedModules": true,
     "experimentalDecorators": true,
-    "importHelpers": true,
-    "target": "ES2022",
-    "module": "preserve"
+    "useDefineForClassFields": false
   },
-  "angularCompilerOptions": {
-    "enableI18nLegacyMessageIdFormat": false,
-    "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "typeCheckHostBindings": true,
-    "strictTemplates": true
-  },
-  "files": [],
-  "references": [
-    {
-      "path": "./tsconfig.app.json"
-    },
-    {
-      "path": "./tsconfig.spec.json"
-    }
-  ]
+  "include": [
+    "src/main.ts",
+    "src/styles.scss",
+    "src/app/app.ts",
+    "src/app/app.scss",
+    "src/app/services/declarations.d.ts",
+    "src/app/services/color-util.service.ts",
+    "src/app/services/color-metrics.service.ts",
+    "src/app/services/bpca.service.ts",
+    "src/app/_candor/accordion/accordion-item.ts",
+    "src/app/_candor/button/button.ts",
+    "src/app/_candor/card/card.ts",
+    "src/app/_candor/form/checkbox/checkbox.ts",
+    "src/app/_candor/form/radio/radio.ts",
+    "src/app/_candor/modal/modal.ts",
+    "src/app/_candor/table/table.ts",
+    "src/app/_candor/toast/toast.ts",
+    "src/app/_candor/tooltip/tooltip.ts",
+    "src/app/_components/alert/alert.ts",
+    "src/app/_components/alert/alert.stories.ts",
+    "src/app/_components/color-contrast/color-contrast.ts",
+    "src/app/_components/color-contrast/color-contrast.stories.ts",
+    "src/app/_components/color-picker/color-picker.ts",
+    "src/app/_components/color-picker/color-picker.stories.ts",
+    "src/app/_components/color-slider/color-slider.ts",
+    "src/app/_components/color-slider/color-slider.stories.ts",
+    "src/app/_components/copy-to-clipboard-button/copy-to-clipboard-button.ts",
+    "src/app/_components/copy-to-clipboard-button/copy-to-clipboard-button.stories.ts",
+    "src/app/_components/metadata/metadata.ts",
+    "src/app/_components/metadata/metadata.stories.ts",
+    "src/app/_components/palette-table/palette-table.ts",
+    "src/app/_components/tone-picker/tone-picker.ts",
+    ".storybook/main.ts",
+    ".storybook/preview.ts"
+  ],
+  "exclude": ["node_modules", "dist"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    outDir: 'dist',
+    target: 'es2022',
+  },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: 'modern-compiler',
+      },
+    },
+  },
+});


### PR DESCRIPTION
Closes #144

Upgrades `@pawn002/okca` from `^1.0.1` to `^2.0.2`.

## The API didn't change; the numbers did

`contrast(fg, bg) → number | null` is unchanged, so `color-metrics.service.ts` needed no code change. v2.0.0 recalibrated the algorithm, so **displayed scores move**:

| | v1.0.1 | v2.0.2 |
|---|---:|---:|
| white on black | 21 | **20.9** |
| black on white | 20 | 20 |
| white on `#767676` (WCAG AA anchor) | 3.5 | **3.9** |
| hot pink on `#1a1a1a` | 3.6 | 3.6 |

- `POL_K` 1.175 → 1.100 moves the AA boundary anchor; `CHROMA_K` 0.50 → 0.65 loosens mid-tone neutrals and brand chromatics by roughly +0.4–0.5
- The light-on-dark cap dropped to `LOD_CAP = 20.9` so every OKCA score sits *strictly* below the WCAG equivalent. Dark-on-light is uncapped and still tops out at 20
- Saturated-colour catches are preserved, and AA (4.5) / AAA (7.0) thresholds are unchanged — so the `>= 4.5` / `>= 3` pass-fail logic in `metadata.ts` is unaffected

v2.0.2 also fixes okca's ESM entry point, which failed under native Node ESM. Vite had been masking it by resolving extensionless specifiers itself, so the app was never broken by it.

## Tests

`color-metrics.service.spec.ts` is ported from Angular `TestBed` to plain vitest. It had to be — **every spec in this repo still imports `@angular/core/testing` and the suite collects zero tests** after the Lit migration, so there was no safety net for a change that moves score values. Filed as #145 for the rest.

The okca assertions now pin the v2 anchors (20.9 / 20 / 3.9 / 3.6) instead of the loose `<= 21` bound that would have passed either way, plus a new block spot-checking the `OKCA <= WCAG` guarantee at the app's call site. 44 tests pass.

## Verification

`npm run build` clean. Checked in the running app:

- `?fg=%23ffffff&bg=%23000000` → score reads **20.9**
- `?fg=%23ffffff&bg=%23767676` → OKCA **3.9** vs WCAG 2 **4.5**; text fails, large text passes

## Docs

`README.md` (scale note, algorithm section, changelog entry), the OKCA note modal in both `app.ts` and the stale `app.html`, and `documentation/services.md` — which had a pinned `4.0` example that is now 3.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QmC2qZBafzvLA2EK96WCR
