### PR TITLE
test: add Lit component test harness and first three specs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       "devDependencies": {
         "@types/d3": "^7.4.3",
         "@types/lodash-es": "^4.17.12",
+        "jsdom": "^29.1.1",
         "sass": "^1.89.0",
         "typescript": "~5.7.3",
         "vite": "^6.3.5",
@@ -42,6 +43,57 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -1438,6 +1490,19 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
       }
     },
     "node_modules/@candor-design/tokens": {
@@ -4654,6 +4719,146 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -9027,6 +9232,16 @@
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -9772,6 +9987,20 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-7.0.0.tgz",
@@ -10218,6 +10447,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -10234,6 +10477,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -11210,6 +11460,37 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer/node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
@@ -11647,6 +11928,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -11786,6 +12074,85 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "devOptional": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/jsesc": {
@@ -12112,6 +12479,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "devOptional": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -12902,12 +13276,12 @@
       }
     },
     "node_modules/parse5": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
       "license": "MIT",
       "dependencies": {
-        "entities": "^6.0.0"
+        "entities": "^8.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -12952,12 +13326,12 @@
       }
     },
     "node_modules/parse5/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -13273,6 +13647,16 @@
       "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/pvtsutils": {
       "version": "1.3.6",
@@ -13695,6 +14079,19 @@
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",
@@ -14367,6 +14764,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/tapable": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
@@ -14544,6 +14948,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -14563,6 +14987,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-dump": {
@@ -14977,6 +15427,19 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
@@ -15005,6 +15468,16 @@
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/webpack": {
       "version": "5.106.2",
@@ -15126,6 +15599,49 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/whatwg-url/node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/which": {
@@ -15250,6 +15766,23 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@types/d3": "^7.4.3",
     "@types/lodash-es": "^4.17.12",
+    "jsdom": "^29.1.1",
     "sass": "^1.89.0",
     "typescript": "~5.7.3",
     "vite": "^6.3.5",

--- a/src/app/_candor/button/button.spec.ts
+++ b/src/app/_candor/button/button.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import './button';
+import { mount, update, flush, cleanup } from '../../test-utils';
+
+afterEach(cleanup);
+
+describe('candor-button', () => {
+  it('registers the custom element', () => {
+    expect(customElements.get('candor-button')).toBeDefined();
+  });
+
+  it('renders a native button with the default variant and size', async () => {
+    const el = await mount('candor-button');
+    const button = el.querySelector('button');
+
+    expect(button).not.toBeNull();
+    expect(button!.className).toBe('button button--primary button--medium');
+    expect(button!.type).toBe('button');
+  });
+
+  it('reflects variant and size into the class list', async () => {
+    const el = await mount('candor-button', { variant: 'destructive', size: 'icon' });
+    expect(el.querySelector('button')!.className).toBe('button button--destructive button--icon');
+  });
+
+  it('applies the disabled attribute', async () => {
+    const el = await mount('candor-button', { disabled: true });
+    expect(el.querySelector('button')!.disabled).toBe(true);
+  });
+
+  it('omits aria-label when none is given', async () => {
+    const el = await mount('candor-button');
+    expect(el.querySelector('button')!.hasAttribute('aria-label')).toBe(false);
+  });
+
+  it('sets aria-label when given', async () => {
+    const el = await mount('candor-button', { ariaLabel: 'Close dialog' });
+    expect(el.querySelector('button')!.getAttribute('aria-label')).toBe('Close dialog');
+  });
+
+  it('emits a composed, bubbling "clicked" event', async () => {
+    const el = await mount('candor-button');
+    let received: CustomEvent | null = null;
+    document.body.addEventListener('clicked', (e) => (received = e as CustomEvent));
+
+    el.querySelector('button')!.click();
+
+    expect(received).not.toBeNull();
+    expect(received!.bubbles).toBe(true);
+    expect(received!.composed).toBe(true);
+  });
+
+  it('does not emit "clicked" while disabled', async () => {
+    const el = await mount('candor-button', { disabled: true });
+    let count = 0;
+    document.body.addEventListener('clicked', () => count++);
+
+    el.querySelector('button')!.click();
+
+    expect(count).toBe(0);
+  });
+
+  // Documents the light-DOM slot bug (#151). The component renders a <slot>
+  // while createRenderRoot() returns `this`, so authored content is never
+  // projected into the <button> — it lands beside it instead, leaving the
+  // control empty and unnamed. Unskip once a fix direction is chosen.
+  it.skip('projects authored content into the button', async () => {
+    document.body.innerHTML = '<candor-button>Save changes</candor-button>';
+    const el = document.querySelector('candor-button')!;
+    await flush(el);
+
+    expect(el.querySelector('button')!.textContent!.trim()).toBe('Save changes');
+  });
+
+  it('stops emitting once disabled is set after mount', async () => {
+    const el = await mount('candor-button');
+    let count = 0;
+    document.body.addEventListener('clicked', () => count++);
+
+    el.querySelector('button')!.click();
+    expect(count).toBe(1);
+
+    await update(el, { disabled: true });
+    el.querySelector('button')!.click();
+    expect(count).toBe(1);
+  });
+});

--- a/src/app/_candor/form/checkbox/checkbox.spec.ts
+++ b/src/app/_candor/form/checkbox/checkbox.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import './checkbox';
+import { mount, update, cleanup } from '../../../test-utils';
+
+afterEach(cleanup);
+
+describe('candor-checkbox', () => {
+  it('registers the custom element', () => {
+    expect(customElements.get('candor-checkbox')).toBeDefined();
+  });
+
+  it('renders an input wired to its label', async () => {
+    const el = await mount('candor-checkbox', { label: 'Constant chroma' });
+    const input = el.querySelector('input')!;
+    const label = el.querySelector('label')!;
+
+    expect(input.type).toBe('checkbox');
+    expect(label.getAttribute('for')).toBe(input.id);
+    expect(el.querySelector('.checkbox-label')!.textContent).toBe('Constant chroma');
+  });
+
+  it('prefers an explicit input-id over the generated one', async () => {
+    const el = await mount('candor-checkbox', { inputId: 'show-gradient' });
+    expect(el.querySelector('input')!.id).toBe('show-gradient');
+    expect(el.querySelector('label')!.getAttribute('for')).toBe('show-gradient');
+  });
+
+  it('generates a unique id when none is supplied', async () => {
+    const a = await mount('candor-checkbox');
+    const b = await mount('candor-checkbox');
+
+    const idA = a.querySelector('input')!.id;
+    const idB = b.querySelector('input')!.id;
+
+    expect(idA).toBeTruthy();
+    expect(idA).not.toBe(idB);
+  });
+
+  it('reflects checked and disabled', async () => {
+    const el = await mount('candor-checkbox', { checked: true, disabled: true });
+    const input = el.querySelector('input')!;
+
+    expect(input.checked).toBe(true);
+    expect(input.disabled).toBe(true);
+    expect(el.querySelector('label')!.className).toContain('checkbox-wrapper--disabled');
+  });
+
+  it('emits "changed" with the new state and updates its own property', async () => {
+    const el = await mount('candor-checkbox');
+    const received: boolean[] = [];
+    document.body.addEventListener('changed', (e) => received.push((e as CustomEvent).detail));
+
+    const input = el.querySelector('input')!;
+    input.checked = true;
+    input.dispatchEvent(new Event('change'));
+
+    expect(received).toEqual([true]);
+    expect(el.checked).toBe(true);
+  });
+
+  it('emits a composed, bubbling event so it escapes nested markup', async () => {
+    const el = await mount('candor-checkbox');
+    let event: CustomEvent | null = null;
+    document.body.addEventListener('changed', (e) => (event = e as CustomEvent));
+
+    const input = el.querySelector('input')!;
+    input.checked = true;
+    input.dispatchEvent(new Event('change'));
+
+    expect(event!.bubbles).toBe(true);
+    expect(event!.composed).toBe(true);
+  });
+
+  it('re-renders when checked is set programmatically', async () => {
+    const el = await mount('candor-checkbox');
+    expect(el.querySelector('input')!.checked).toBe(false);
+
+    await update(el, { checked: true });
+    expect(el.querySelector('input')!.checked).toBe(true);
+  });
+});

--- a/src/app/_components/color-contrast/color-contrast.spec.ts
+++ b/src/app/_components/color-contrast/color-contrast.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import './color-contrast';
+import { mount, update, cleanup } from '../../test-utils';
+
+afterEach(cleanup);
+
+const score = (el: Element) => el.querySelector('#contrast-score')!.textContent!.trim();
+
+describe('cc-color-contrast', () => {
+  it('registers the custom element', () => {
+    expect(customElements.get('cc-color-contrast')).toBeDefined();
+  });
+
+  it('defaults to the okca contrast type', async () => {
+    const el = await mount('cc-color-contrast');
+    expect(el.contrastType).toBe('okca');
+  });
+
+  it('renders the OKCA light-on-dark cap for white on black', async () => {
+    const el = await mount('cc-color-contrast', { colorOne: '#ffffff', colorTwo: '#000000' });
+    expect(score(el)).toBe('20.9');
+  });
+
+  it('renders the OKCA dark-on-light ceiling for black on white', async () => {
+    const el = await mount('cc-color-contrast', { colorOne: '#000000', colorTwo: '#ffffff' });
+    expect(score(el)).toBe('20');
+  });
+
+  it('is polarity-aware — swapping the pair changes the score', async () => {
+    const el = await mount('cc-color-contrast', { colorOne: '#ffffff', colorTwo: '#000000' });
+    const lightOnDark = score(el);
+
+    await update(el, { colorOne: '#000000', colorTwo: '#ffffff' });
+    expect(score(el)).not.toBe(lightOnDark);
+  });
+
+  it('recomputes when the contrast type changes', async () => {
+    const el = await mount('cc-color-contrast', { colorOne: '#000000', colorTwo: '#ffffff' });
+    const okca = score(el);
+
+    await update(el, { contrastType: 'apca' });
+    expect(score(el)).not.toBe(okca);
+  });
+
+  it('maps "apca object" to a minimum object dimension', async () => {
+    const el = await mount('cc-color-contrast', {
+      colorOne: '#000000',
+      colorTwo: '#ffffff',
+      contrastType: 'apca object',
+    });
+
+    // A very high APCA score collapses to the smallest dimension, not a ratio.
+    expect(Number(score(el))).toBeLessThan(2);
+  });
+
+  it('renders a fallback marker when inputs are missing', async () => {
+    const el = await mount('cc-color-contrast');
+    expect(score(el)).toBe('!');
+  });
+
+  it('announces the score to assistive tech via a live region', async () => {
+    const el = await mount('cc-color-contrast', { colorOne: '#ffffff', colorTwo: '#000000' });
+    const live = el.querySelector('[role="status"]')!;
+
+    expect(live.getAttribute('aria-live')).toBe('polite');
+    expect(live.textContent!.trim()).toBe('Contrast score: 20.9');
+  });
+
+  it('hides the decorative score container from assistive tech', async () => {
+    const el = await mount('cc-color-contrast', { colorOne: '#ffffff', colorTwo: '#000000' });
+    expect(el.querySelector('.comp-container')!.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('leaves the announcement empty when there is no score', async () => {
+    const el = await mount('cc-color-contrast');
+    expect(el.contrastAnnouncement).toBe('');
+  });
+});

--- a/src/app/test-utils.ts
+++ b/src/app/test-utils.ts
@@ -1,0 +1,42 @@
+/**
+ * Helpers for exercising the Lit elements in vitest.
+ *
+ * Every component in this app overrides `createRenderRoot()` to return `this`,
+ * so rendered markup lands in the light DOM and is queryable directly off the
+ * element — no shadow root traversal.
+ */
+
+/**
+ * Mounts an element, sets properties, and waits for the first render.
+ *
+ * Properties are assigned rather than set as attributes so that non-string
+ * types (booleans, objects) reach the component as-is.
+ */
+export async function mount<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  props: Partial<HTMLElementTagNameMap[K]> = {},
+): Promise<HTMLElementTagNameMap[K]> {
+  const el = document.createElement(tag);
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await flush(el);
+  return el;
+}
+
+/** Waits for a Lit element to finish its pending render. */
+export async function flush(el: Element): Promise<void> {
+  const updateComplete = (el as { updateComplete?: Promise<unknown> }).updateComplete;
+  if (updateComplete) await updateComplete;
+}
+
+/** Sets properties on a mounted element and waits for the re-render. */
+export async function update<T extends Element>(el: T, props: Partial<T>): Promise<T> {
+  Object.assign(el, props);
+  await flush(el);
+  return el;
+}
+
+/** Removes everything mounted during a test. */
+export function cleanup(): void {
+  document.body.innerHTML = '';
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,9 @@ export default defineConfig({
   },
   test: {
     include: ['src/**/*.spec.ts'],
+    // Component specs need a DOM to define and upgrade custom elements. The
+    // service specs are pure and don't care either way.
+    environment: 'jsdom',
     // A run that collects no tests is a broken suite, not a passing one — this
     // is how the Angular-era specs sat dead after the Lit migration without
     // anyone noticing.


### PR DESCRIPTION
Closes the remaining item on #145. Component coverage was zero — the suite only reached the three services.

## Harness

`src/app/test-utils.ts` (`mount` / `update` / `flush` / `cleanup`), and the vitest environment switched to jsdom. Every component overrides `createRenderRoot()` to return `this`, so rendered markup is queryable straight off the element with no shadow-root traversal — which keeps the helpers to about 30 lines.

## Specs

Three, picked to prove the harness generalises rather than to chase a coverage number:

- **`candor-button`** — variant/size class mapping, disabled, aria-label presence/absence, and that `clicked` is composed + bubbling and stops firing when `disabled` is set *after* mount
- **`candor-checkbox`** — label↔input `for` wiring, explicit vs generated ids, id uniqueness across instances, `changed` round-tripping into the component's own property
- **`cc-color-contrast`** — pins the OKCA v2 anchors *through the component* (20.9 light-on-dark, 20 dark-on-light), polarity, recompute on type change, the `apca object` dimension path, and the `aria-live` announcement

**198 tests pass** (1 skipped, below).

## This turned up a real bug — #151

Six `_candor` components render a `<slot>` while rendering into the **light DOM**, where slots are inert. Lit appends its template *after* existing children rather than replacing them, so authored content becomes a **sibling** of the control meant to wrap it.

Measured against a production build:

| | |
|---|---:|
| `candor-button`s whose inner `<button>` is empty | **19 / 19** |
| where the visible content does not overlap the clickable `<button>` | **15 / 19** |
| with no accessible name at all | **1** |

For "Swap Selected Colors" the icon sits at `x=204` and the real 16×16 button at `x=230` — disjoint. Clicking the icon fires zero events.

**Not deployed** — `docs/` still holds the pre-Lit Angular build (`<app-root>`, 2026-04-27), so no user impact today. It ships on the next `deploy:gh-pages`.

`button.spec.ts` carries a **skipped** test asserting the correct behaviour. Unskip it when a fix direction is picked — see #151 for the three options; the short version is that #149 (adopt `@candor-design/web-components`) fixes all six by deleting all six.

## Verification

- `npm test` — 198 passed, 1 skipped
- `npm run build` — byte-identical output
- `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QmC2qZBafzvLA2EK96WCR
