### PR TITLE
feat(ci): add CI, Pages deploy, and draft-release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# A branch only needs its newest run. Superseded runs are cancelled so a quick
+# follow-up push does not queue behind the commit it just replaced.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      # Node 18 is out of support and Vite 6 does not target it; okca's matrix
+      # still carries it, candor's does not. Following candor here.
+      matrix:
+        node-version: [20, 22]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build
+      # `npm test` is a single vitest run that exits with a status code, in Node
+      # with no browser. It is configured with `passWithNoTests: false`, which is
+      # what makes this job meaningful: the suite sat dead and uncollected for
+      # months after the Lit migration (#145) because a run collecting zero tests
+      # looked exactly like a run that passed.
+      - run: npm test
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+      - run: npm ci
+      # The build does NOT type-check — `vite build` transpiles and strips types
+      # without ever running the compiler, so nothing in this repo checked them
+      # anywhere. That is not hypothetical: when this job was added, `tsc
+      # --noEmit` immediately reported two genuine errors in candor-package.spec
+      # that had been sitting in the tree unread. Same shape as candor#237.
+      #
+      # It is a separate job from `test` because it is not per-Node-version:
+      # the compiler's answer does not change with the runtime.
+      - run: npm run typecheck

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,58 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  # Manual re-run, for redeploying an unchanged commit — a Pages settings change
+  # or a failed deploy should not need an empty commit to recover from.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  # OIDC, which is how actions/deploy-pages authenticates. No stored secret.
+  id-token: write
+
+# One deploy at a time, and never cancel one in flight: a half-finished upload
+# that loses its race leaves the live site on whatever partial state it reached.
+# Queueing costs a minute; cancelling costs an outage.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+      - run: npm ci
+
+      # The same gates as CI, re-run here rather than assumed. CI and this
+      # workflow are triggered independently by the same push, so nothing
+      # otherwise stops a red CI run and a green deploy from racing — and the
+      # one that ships is the one that matters.
+      - run: npm run typecheck
+      - run: npm test
+
+      # --base=/color-pair-quick-iterator/ because the site is served from a
+      # repo subpath, not a domain root. Without it every asset URL resolves
+      # against / and the page loads blank.
+      - run: npm run build:gh-pages
+
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,33 @@
+name: Draft Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  draft-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Verify tag is on main
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor $GITHUB_SHA origin/main || \
+            (echo "Error: tag is not on main branch" && exit 1)
+      - name: Generate release notes
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          PREV_TAG=$(git tag --sort=-v:refname | grep '^v' | sed -n '2p')
+          if [ -n "$PREV_TAG" ]; then
+            NOTES_FLAG="--generate-notes --notes-start-tag $PREV_TAG"
+          else
+            NOTES_FLAG="--generate-notes"
+          fi
+          gh release create "$TAG" --draft --title "$TAG" $NOTES_FLAG
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,9 +47,12 @@ Tests run on **vitest** (not Karma/Jasmine). Use `vi.spyOn(...).mockReturnValue(
 
 1. Make code changes
 2. Update/add corresponding tests
-3. Run `npm run build` to verify TypeScript compilation
-4. Run `npm test` — a single vitest run that exits with a status code. It runs in Node with no browser needed
-5. Commit both implementation and test changes together
+3. Run `npm run typecheck` to verify TypeScript. **`npm run build` does not do this** — `vite build` transpiles and strips types without ever invoking the compiler, so a type error passes the build and ships. Two real ones sat unread in `candor-package.spec.ts` until CI started checking
+4. Run `npm run build` to verify the bundle actually builds
+5. Run `npm test` — a single vitest run that exits with a status code. It runs in Node with no browser needed
+6. Commit both implementation and test changes together
+
+CI runs steps 3–5 on every push and PR to `main` (`.github/workflows/ci.yml`), so a miss is caught — but locally is cheaper than a red PR.
 
 `npm test` is configured with `passWithNoTests: false`: a run that collects zero tests fails. This is deliberate — the Angular-era specs sat dead and uncollected for months after the Lit migration because `npm test` was watch mode and never exited.
 
@@ -74,9 +77,10 @@ When the user requests that the project's documentation be updated:
 
 ```bash
 npm start                  # Development server (vite)
-npm run build              # Production build (generic, works anywhere)
+npm run build              # Production build (generic, works anywhere) — does NOT type-check
+npm run typecheck          # tsc --noEmit; the only thing that type-checks this repo
 npm run build:gh-pages     # Build for this repo's GitHub Pages (output to dist/ only)
-npm run deploy:gh-pages    # Build, copy to docs/, commit, and push — full deploy to GitHub Pages
+npm run deploy:gh-pages    # Manual deploy: build, copy to docs/, commit, push
 npm test                   # Run unit tests once with vitest (exits with a status code)
 npm run test:watch         # Run vitest in watch mode
 ```

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "vite",
     "build": "vite build",
+    "typecheck": "tsc --noEmit",
     "build:gh-pages": "vite build --base=/color-pair-quick-iterator/",
     "deploy:gh-pages": "npm run build:gh-pages && rm -rf docs/* && cp -r dist/* docs/ && git add docs/ && git commit -m \"build: update GitHub Pages deployment with latest changes\" && git push",
     "preview": "vite preview",

--- a/src/app/candor-package.spec.ts
+++ b/src/app/candor-package.spec.ts
@@ -28,6 +28,20 @@ afterEach(cleanup);
  * jsdom does no layout, so the clipping assertions below read the rule that
  * causes it rather than measuring a rendered box.
  */
+/**
+ * Calls `candor-radio`'s private group lookup.
+ *
+ * Reaching a private member is the point: what this file pins is *how* the
+ * upstream element resolves its group, which is the behaviour app.ts depends on
+ * and which no public API exposes. The cast goes via `unknown` because the
+ * declared type says `_groupSiblings` is private, so the two types do not
+ * overlap and a direct assertion is a compile error — one `tsc` only started
+ * reporting once CI began type-checking at all.
+ */
+function groupSiblingsOf(el: Element | null): unknown[] {
+  return (el as unknown as { _groupSiblings(): unknown[] })._groupSiblings();
+}
+
 function styleSheetOf(tag: string): string {
   const ctor = customElements.get(tag) as (CustomElementConstructor & { styles?: unknown }) | undefined;
   const styles = ctor?.styles;
@@ -304,10 +318,7 @@ describe('candor-radio', () => {
     }
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    const first = fieldset.querySelector('candor-radio') as HTMLElement & {
-      _groupSiblings(): unknown[];
-    };
-    expect(first._groupSiblings()).toHaveLength(values.length);
+    expect(groupSiblingsOf(fieldset.querySelector('candor-radio'))).toHaveLength(values.length);
 
     // Same radios, no fieldset: each wrapper yields a group of one.
     const loose = document.createElement('div');
@@ -319,7 +330,7 @@ describe('candor-radio', () => {
     document.body.appendChild(loose);
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect((lone as HTMLElement & { _groupSiblings(): unknown[] })._groupSiblings()).toHaveLength(1);
+    expect(groupSiblingsOf(lone)).toHaveLength(1);
 
     fieldset.remove();
     loose.remove();


### PR DESCRIPTION
Closes #134.

Three workflows, modelled on the `okca` and `candor` pipelines.

## What's here

| Workflow | Trigger | Does |
|---|---|---|
| `ci.yml` | push/PR to `main` | `npm ci` → build → test on Node 20 and 22, plus a separate `typecheck` job |
| `deploy.yml` | push to `main`, or manual | typecheck → test → `build:gh-pages` → publish via `actions/deploy-pages` |
| `draft-release.yml` | push of a `v*` tag | verifies the tag is on `main`, drafts a release from commits since the previous tag |

No stored secrets anywhere — Pages deploys over OIDC with the built-in `GITHUB_TOKEN`, same philosophy as the npm trusted publishing in the sibling repos. `draft-release.yml` is verbatim from okca, as the issue asked.

## Nothing in this repo type-checked

`vite build` transpiles and strips types without ever invoking the compiler, so CLAUDE.md's instruction to "run `npm run build` to verify TypeScript compilation" was never true — a type error passed the build and shipped.

Adding `npm run typecheck` (`tsc --noEmit`) immediately surfaced **two real errors** that had been sitting unread in `candor-package.spec.ts`: casts to a private `_groupSiblings` that TypeScript rejects because the types cannot overlap. Fixed here by going through `unknown`, with a comment on why the spec reaches a private member at all. This is the candor#237 shape — a compiler naming a genuine problem that nothing was listening to.

CLAUDE.md is corrected accordingly.

## Two decisions worth reviewing

**Node matrix is `[20, 22]`, not okca's `[18, 20, 22]`.** Node 18 is out of support and Vite 6 does not target it; candor already dropped it. Say the word if you'd rather match okca exactly.

**The deploy job re-runs typecheck and tests instead of trusting CI.** `ci.yml` and `deploy.yml` are triggered independently by the same push, so nothing otherwise stops a red CI run and a green deploy from racing — and the one that ships is the one that matters. The cost is roughly a duplicated minute per deploy.

## This does not switch the deploy over yet

`deploy.yml` will not take effect until the Pages source moves from **branch `main` / `docs`** to **GitHub Actions**, which is a repo settings change I deliberately left out. Until it is flipped:

- the workflow runs and builds, but publishes nothing
- `npm run deploy:gh-pages` stays the live path
- so this PR is additive and cannot break the site

Once flipped, `docs/` stops being a deploy target and the ~1 MB of committed build output in it can go, along with the `deploy:gh-pages` script. Worth doing as a follow-up rather than bundled in here.

## Verified

`npm run typecheck`, `npm test` (238 passing, 9 files), and `npm run build` all clean locally; all three workflow files parse as YAML. CI itself will get its first real exercise on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QmC2qZBafzvLA2EK96WCR
